### PR TITLE
User can update students slack id

### DIFF
--- a/app/views/user/students/edit.html.erb
+++ b/app/views/user/students/edit.html.erb
@@ -10,7 +10,7 @@
   </p>
     <p class='s-p'>
     <%= f.label 'Slack Account: ' %>
-    <%= f.select :slack_id, options_for_select(slack_members(@student.turing_module), @student.slack_id.to_s), {class: "select-field"}%>
+    <%= f.text_field :slack_id %>
   </p>
   <%= f.submit 'Save Changes', class: 's-button', data: {confirm: 'Are you sure you want to update this student?'} %>
 <% end %>

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :student do
     turing_module
     sequence(:zoom_id) { |n| "<zoom_id>_#{n}" }
+    sequence(:slack_id) {|n| "<slack_id_#{n}"}
     name { Faker::Name.name }
 
-    factory :student_with_slack_id do
-      sequence(:slack_id) {|n| "<slack_id_#{n}"}
-    end
+    # factory :student_with_slack_id do
+    # end 
   end
 end

--- a/spec/features/students/show_spec.rb
+++ b/spec/features/students/show_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Student Show Page' do
   end
 
   it 'displays the students name, zoom id, slack id, and module name' do
-    student = create(:student_with_slack_id)
+    student = create(:student)
 
     visit student_path(student)
 
@@ -27,11 +27,11 @@ RSpec.describe 'Student Show Page' do
   end
 
   it 'shows that a slack id hasnt been assigned if there is no slack id' do 
-    student = create(:student)
+    student = create(:student, slack_id: nil)
     
     visit student_path(student)
 
-    expect(page).to have_content("Not Yet Assigned")
+    expect(page).to have_content("Slack ID: Not Yet Assigned")
   end 
 
   it 'the module name is a link' do

--- a/spec/features/students/update_spec.rb
+++ b/spec/features/students/update_spec.rb
@@ -22,23 +22,28 @@ RSpec.describe 'Student Update' do
 
     expect(find('#student_name').value).to eq(student.name)
     expect(find('#student_zoom_id').value).to eq(student.zoom_id)
+    expect(find('#student_slack_id').value).to eq(student.slack_id)
   end
 
   it 'can update the students info' do
     student = create(:student)
     new_name = 'Different Name'
     new_zoom_id = '<zoom_id_thats_different>'
+    new_slack_id = '<slack_id_thats_different>'
 
     visit edit_student_path(student)
 
     fill_in :student_name, with: new_name
     fill_in :student_zoom_id, with: new_zoom_id
+    fill_in :student_slack_id, with: new_slack_id
 
     click_button 'Save Changes'
 
     expect(current_path).to eq(student_path(student))
     expect(page).to have_content("Your changes have been saved.")
     expect(page).to have_content(new_name)
+    expect(page).to have_content(new_zoom_id)
+    expect(page).to have_content(new_slack_id)
   end
 
   xit 'wont save if changes are invalid' do
@@ -52,24 +57,4 @@ RSpec.describe 'Student Update' do
     expect(page).to have_content('Zoom can\'t be blank')
   end
 
-  it 'can update slack id for that user' do 
-    test_module = create(:turing_module)
-    student = create(:student_with_slack_id, turing_module: test_module)
-
-    create_list(:slack_member, 10, turing_module: test_module)
-    slack_member = create(:slack_member, turing_module: test_module, slack_user_id:"new-slack-id")
-
-    visit edit_student_path(student)
-
-    select(slack_member.name)
-
-    click_button 'Save Changes'
-
-    student.reload
-
-    expect(current_path).to eq(student_path(student))
-    expect(page).to have_content("Your changes have been saved.")
-    expect(student.slack_id).to eq(slack_member.slack_user_id)
-    expect(page).to have_content(slack_member.slack_user_id)
-  end 
 end


### PR DESCRIPTION
__x__ Wrote Tests ____ Implemented ____ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [ ] New feature
- [x] Bug Fix
- [x] Refactor

## Description of Change:

    description: No longer updating slack id with dropdown. Instead, have text field to do that. 

## Requested feedback:

    I'd like feedback on... n/a

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link:
![image](https://user-images.githubusercontent.com/40842258/221324567-ffde227c-05ba-4f87-bd85-9a1175a9f7ee.png)

