### PR TITLE
Add conditional to take attendance on dashboard only if setup is complete

### DIFF
--- a/app/views/user/attendances/new.html.erb
+++ b/app/views/user/attendances/new.html.erb
@@ -2,5 +2,5 @@
 <p class='s-p'><%= link_to "#{@module.inning.name} inning", inning_path(@module.inning) %> </p>
 <h3 class='s-h3'>Take Attendance for a Zoom Meeting</h3>
 <%= render partial: 'shared/take_zoom_attendance', locals: {attendance: @attendance, mod: @module} %>
-<h3 class='s-h3'>Take Attendance for a Slack Meeting</h3>
+<h3 class='s-h3'>Take Attendance for a Slack Thread</h3>
 <%= render partial: 'shared/take_slack_attendance', locals: {mod: @module} %>

--- a/app/views/user/dashboard/show.html.erb
+++ b/app/views/user/dashboard/show.html.erb
@@ -1,10 +1,14 @@
 <h1>Welcome <%= current_user.email %>!</h1>
 <% if @my_module %>
   <h2>My Module: <%= link_to @my_module.name, turing_module_path(@my_module) %></h2>
-  <h3>Take Attendance for a Zoom Meeting</h3>
-  <%= render partial: 'shared/take_zoom_attendance', locals: {attendance: Attendance.new, mod: @my_module} %>
-  <h3>Take Attendance for a Slack Meeting</h3>
-<%= render partial: 'shared/take_slack_attendance', locals: {mod: @my_module} %>
+  <% if @my_module.account_match_complete %>
+    <h3>Take Attendance for a Zoom Meeting</h3>
+    <%= render partial: 'shared/take_zoom_attendance', locals: {attendance: Attendance.new, mod: @my_module} %>
+    <h3>Take Attendance for a Slack Thread</h3>
+    <%= render partial: 'shared/take_slack_attendance', locals: {mod: @my_module} %>
+  <% else %>
+    <p><%= link_to "Setup Module", turing_module_populi_integration_path(@my_module), class: 's-button' %></p>
+  <% end %>
 <% elsif current_inning %>
   <p>My Module is not set. To set My Module visit a module page.</p>
   <h2>Current Inning: <%= current_inning.name %></h2>

--- a/spec/features/attendances/create_slack_attendance_spec.rb
+++ b/spec/features/attendances/create_slack_attendance_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Creating an Attendance' do
       expect(current_path).to eq("/modules/#{@test_module.id}/attendances/new")
       expect(page).to have_content(@test_module.name)
       expect(page).to have_content(@test_module.inning.name)
-      expect(page).to have_content('Take Attendance for a Slack Meeting')
+      expect(page).to have_content('Take Attendance for a Slack Thread')
 
       fill_in :slack_url, with: slack_url
       click_button 'Take Slack Attendance'

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -24,12 +24,27 @@ RSpec.describe "Dashboard" do
       expect(page).to have_link(@my_mod.name, href: turing_module_path(@my_mod))
     end
 
-    it 'user can take attendance for their mod' do
+    it 'user cant take attendance for their mod if account match isnt complete' do
       visit '/'
 
+      expect(page).to have_link("Setup Module")
+      expect(page).to_not have_content('Take Attendance for a Zoom Meeting')
+      expect(page).to_not have_content('Take Attendance for a Slack Thread')
+    end
+
+    it 'user can take attendance for their mod if account match is complete' do
+      create_list(:student, 10, turing_module: @my_mod)
+      @my_mod.reload
+
+      visit '/'
+
+      expect(page).to_not have_link("Setup Module")
       expect(page).to have_content('Take Attendance for a Zoom Meeting')
+      expect(page).to have_content('Take Attendance for a Slack Thread')
       expect(page.find('form#take-zoom-attendance')['method']).to eq('post')
       expect(page.find('form#take-zoom-attendance')['action']).to eq(turing_module_attendances_path(@my_mod))
+      expect(page.find('form#take-slack-attendance')['method']).to eq('post')
+      expect(page.find('form#take-slack-attendance')['action']).to eq(turing_module_attendances_path(@my_mod))
     end
 
     it 'does not show current inning info' do


### PR DESCRIPTION

__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- x ] The code will run locally

## Type of change

- [ ] New feature
- [x] Bug Fix
- [x] Refactor

## Description of Change:

    description: Add conditional on dashboard page so users are prompted to set up module if they never set it up before.

## Requested feedback:

    I'd like feedback on... n/a

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link:

![image](https://media.tenor.com/0UJa-x2w3jsAAAAC/arewehavingfunyet.gif)