### PR TITLE
Select not present if no match 156 157

### DIFF
--- a/app/facades/account_match_facade.rb
+++ b/app/facades/account_match_facade.rb
@@ -12,7 +12,7 @@ class AccountMatchFacade
   def slack_options
     @slack_options ||= slack_channel_members.map do |member|
       [member[:attributes][:name], member[:attributes][:slack_user_id]]
-    end 
+    end.push(["Not In Channel", nil])
   end
 
   def best_matching_slacker(student)
@@ -30,7 +30,7 @@ class AccountMatchFacade
   def zoom_options
     @zoom_options ||= participants.map do |participant|
       [participant.name, participant.id]
-    end
+    end.push(["Not Present", nil])
   end
 
   def best_matching_zoomer(student)

--- a/spec/features/modules/setup_spec.rb
+++ b/spec/features/modules/setup_spec.rb
@@ -188,6 +188,34 @@ RSpec.describe "Module Setup" do
             end
           end
 
+          it 'user can select Not Present if the student wasnt in the zoom meeting' do
+            student = @mod.students.find_by(name: "Anthony Blackwell Tallent")
+            within "#student-#{student.id}" do
+              within '.zoom-select' do 
+                select "Not Present"
+              end
+            end
+            click_button "Match"
+
+            student.reload 
+
+            expect(student.zoom_id).to be_empty
+          end
+
+          it 'user can select Not In Channel if the student isnt in the slack channel yet' do
+            student = @mod.students.find_by(name: "Anthony Blackwell Tallent")
+            within "#student-#{student.id}" do
+              within '.slack-select' do 
+                select "Not In Channel"
+              end
+            end
+            click_button "Match"
+
+            student.reload 
+
+            expect(student.slack_id).to be_empty
+          end
+
           it 'only includes one option for each uniq zoom name' do
             options = page.first('.zoom-select').all('option').map do |option|
               option.text


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [x] New feature
- [ ] Bug Fix
- [ ] Refactor

## Description of Change:

    description: Users can select "Not Present" or "Not in Slack Channel" during the 'Account Match' Phase. Users can easily update slack ids if for any reason a student isnt in the slack channel at the time of import. We'll need to rethink the "Add a New Student" upon zoom attendance taken. I think instead of having that button, we can have a dropdown of student names, and have our users select the user that should be matched with that zoom id. 

## Requested feedback:

    I'd like feedback on... n/a

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link:
![image](https://media3.giphy.com/media/NrF0O24dP5NuYund2x/200w.gif?cid=6c09b95298tuxvt0wnmve6djser4smmryp3h9kfsxkk3o4ss&rid=200w.gif&ct=v)