### PR TITLE
Dynamic Omniauth Redirects and Error Handling

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,11 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
+  def failure
+    redirect_to root_path
+    flash[:error] = "We had some trouble logging you in with Google. Please make sure you are signing in with a turing.edu account. If you continue to have issues, please contact the app maintainers."
+  end
+
   def destroy
     session.delete(:user_id)
     redirect_to root_path

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,10 +4,7 @@ OmniAuth.config.silence_get_warning = true
 SETUP_PROC = lambda do |env|
   env['omniauth.strategy'].options[:client_id] = ENV['GOOGLE_OAUTH_CLIENT_ID']
   env['omniauth.strategy'].options[:client_secret] = ENV['GOOGLE_OAUTH_CLIENT_SECRET']
-  env['omniauth.strategy'].options[:scope] = 'spreadsheets,email'
-  unless Rails.env.development?
-    env['access_type'].options[:access_type] = "offline"
-  end
+  env['omniauth.strategy'].options[:scope] = 'email'
 
   # Oauth should redirect back to the originating domain to prevent CSRF errors
   req = Rack::Request.new(env)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,25 +1,20 @@
-Rails.application.config.middleware.use OmniAuth::Builder do
-  if Rails.env.production?
-    provider :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET'],
-    {
-      redirect_uri: 'https://turing-present.herokuapp.com/auth/google_oauth2/callback',
-      scope: 'spreadsheets,email',
-      access_type: 'offline'
-    }
-  elsif Rails.env.staging?
-    provider :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET'],
-    {
-      redirect_uri: 'https://present-staging.turing.edu/auth/google_oauth2/callback',
-      scope: 'spreadsheets,email',
-      access_type: 'offline',
-    }
-  else
-    provider :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET'],
-    {
-      redirect_uri: 'http://localhost:3000/auth/google_oauth2/callback',
-      scope: 'spreadsheets,email'
-    }
-  end
-end
 OmniAuth.config.allowed_request_methods = %i[get post]
 OmniAuth.config.silence_get_warning = true
+
+SETUP_PROC = lambda do |env|
+  env['omniauth.strategy'].options[:client_id] = ENV['GOOGLE_OAUTH_CLIENT_ID']
+  env['omniauth.strategy'].options[:client_secret] = ENV['GOOGLE_OAUTH_CLIENT_SECRET']
+  env['omniauth.strategy'].options[:scope] = 'spreadsheets,email'
+  unless Rails.env.development?
+    env['access_type'].options[:access_type] = "offline"
+  end
+
+  # Oauth should redirect back to the originating domain to prevent CSRF errors
+  req = Rack::Request.new(env)
+  env['omniauth.strategy'].options[:redirect_uri] = "#{req.base_url}/auth/google_oauth2/callback"
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, setup: SETUP_PROC
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   root to: 'user/dashboard#show'
   get '/welcome', to: 'welcome#index'
   get '/auth/google_oauth2/callback', to: 'sessions#create'
+  get '/auth/failure', to: 'sessions#failure'
   delete '/sessions', to: 'sessions#destroy'
 
   scope module: :user do

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Authentication" do
   let(:google_oauth_token){'<OAUTH_TOKEN>'}
   let(:google_refresh_token){'<REFRESH_TOKEN>'}
   let(:organization_domain){'turing.edu'}
+
   before :each do
     create(:inning)
 
@@ -78,5 +79,16 @@ RSpec.describe "Authentication" do
     click_link 'Sign In With Google'
 
     expect(page).to have_content("Welcome, #{email}!")
+  end
+
+  it 'displays a message for auth failure' do
+    OmniAuth.config.mock_auth[:google_oauth2] = :csrf_detected
+
+    visit '/'
+
+    click_link 'Sign In With Google'
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content("We had some trouble logging you in with Google. Please make sure you are signing in with a turing.edu account. If you continue to have issues, please contact the app maintainers.")
   end
 end


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [ x] All Tests are Passing in all environments

- [ x] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Makes Google omniauth setup dynamic so that it will redirect the user back to the originating domain, for example `present.turing.edu` OR `turing-present.herokuapp.com`, wherever the user came from. If Google redirects back to a different domain it will create a CSRF detection error. This allows us to support use of both domains.

Also adds in error handling if there is an auth failure for whatever reason.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media4.giphy.com/media/81xwEHX23zhvy/giphy.gif"/>
