### PR TITLE
User selects attendance time slot to transfer to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 coverage
 
 .ruby-version
+
+dump.rdb

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -147,3 +147,7 @@ form#account-match {
 .alias-correction {
   font-size: 12px;
 }
+
+#populi-attendance-transfer {
+  display: block;
+}

--- a/app/controllers/user/populi_transfer_controller.rb
+++ b/app/controllers/user/populi_transfer_controller.rb
@@ -1,13 +1,16 @@
 class User::PopuliTransferController < User::BaseController
   def new
-    @attendance = Attendance.find(params[:attendance_id])
+    attendance = Attendance.find(params[:attendance_id])
+    render locals: {
+      facade: PopuliTransferFacade.new(attendance)
+    }
   end
 
   def create
-    @attendance = Attendance.find(params[:attendance_id])
-    PopuliTransferJob.perform_async(@attendance.id)
-    flash[:success] = "Transferring attendance to Populi. Please confirm in Populi that #{populi_attendance_link(@attendance)} is accurate."
-    redirect_to @attendance
+    attendance = Attendance.find(params[:attendance_id])
+    PopuliTransferJob.perform_async(attendance.id, params[:populi_meeting_id])
+    flash[:success] = "Transferring attendance to Populi. Please confirm in Populi that #{populi_attendance_link(attendance)} is accurate."
+    redirect_to attendance
   end
 
 private

--- a/app/facades/populi_transfer_facade.rb
+++ b/app/facades/populi_transfer_facade.rb
@@ -1,0 +1,24 @@
+class PopuliTransferFacade
+  include ApplicationHelper
+
+  attr_reader :attendance
+
+  def initialize(attendance)
+    @attendance = attendance
+  end
+
+  def turing_module
+    attendance.turing_module
+  end
+
+  def populi_meeting_options
+    meetings = attendance.meeting.populi_meetings_on_same_day(turing_module.populi_course_id)
+    meetings.map do |populi_meeting|
+      ["#{pretty_time(populi_meeting.start)}", populi_meeting.id]
+    end
+  end
+
+  def populi_meeting_selection
+    attendance.meeting.closest_populi_meeting_to_start_time(turing_module.populi_course_id).id
+  end
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -53,12 +53,11 @@ class Attendance < ApplicationRecord
     student_attendances.where(status: status).count
   end
 
-  def transfer_to_populi!
+  def transfer_to_populi!(populi_meeting_id)
     service = PopuliService.new
     course_id = self.turing_module.populi_course_id
-    populi_meeting = meeting.closest_populi_meeting_to_start_time(course_id)
     student_attendances.includes(:student).each do |student_attendance|
-      response = service.update_student_attendance(course_id, populi_meeting.id, student_attendance.student.populi_id, student_attendance.status)
+      response = service.update_student_attendance(course_id, populi_meeting_id, student_attendance.student.populi_id, student_attendance.status)
       begin
         raise "Student Attendance not updated" unless response[:response][:result] == "UPDATED"
       rescue => error

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -2,9 +2,17 @@ class Meeting < ApplicationRecord
   self.abstract_class = true
 
   def closest_populi_meeting_to_start_time(course_id)
-    data = PopuliService.new.course_meetings(course_id)[:response][:meeting].min_by do |data|
+    meeting_data = PopuliService.new.course_meetings(course_id)[:response][:meeting].min_by do |data|
       (start_time.to_i - data[:start].to_datetime.to_i).abs
     end
-    PopuliMeeting.new(data)
+    PopuliMeeting.new(meeting_data)
+  end
+
+  def populi_meetings_on_same_day(course_id)
+    meeting_day = start_time.to_date
+    meetings = PopuliService.new.course_meetings(course_id)[:response][:meeting].find_all do |data|
+      meeting_day == Date.parse(data[:start])
+    end
+    meetings.map{|data| PopuliMeeting.new(data)}
   end
 end

--- a/app/sidekiq/populi_transfer_job.rb
+++ b/app/sidekiq/populi_transfer_job.rb
@@ -1,7 +1,7 @@
 class PopuliTransferJob
   include Sidekiq::Job
 
-  def perform(attendance_id)
-    Attendance.find(attendance_id).transfer_to_populi!
+  def perform(attendance_id, populi_meeting_id)
+    Attendance.find(attendance_id).transfer_to_populi!(populi_meeting_id)
   end
 end

--- a/app/views/shared/_attendance_details.html.erb
+++ b/app/views/shared/_attendance_details.html.erb
@@ -1,4 +1,4 @@
-<h3><%= attendance.meeting.title %></h3>
+<h3>Title: <%= attendance.meeting.title %></h3>
 <h3>Date: <%= pretty_date(attendance.attendance_time) %></h3>
 <h3>Attendance Time: <%= pretty_time(attendance.attendance_time) %> <%= link_to "Update Attendance Time", edit_attendance_path(attendance) if updatable %></h3>
 <p><strong>Present: <%= attendance.count_status(:present) %>, Tardy: <%= attendance.count_status(:tardy) %>, Absent: <%= attendance.count_status(:absent) %></strong></p>

--- a/app/views/user/populi_transfer/new.html.erb
+++ b/app/views/user/populi_transfer/new.html.erb
@@ -1,6 +1,7 @@
+<h1><%= link_to facade.turing_module.name, turing_module_path(facade.turing_module) %></h1>
+<%= render partial: "shared/attendance_details", locals: {attendance: facade.attendance, updatable: false} %>
 <h1>Transfer Student Attendances to Populi</h1>
-<%= render partial: "shared/attendance_details", locals: {attendance: @attendance, updatable: false} %>
-<p>To transfer these attendance results to Populi, you must first create the Populi attendance record by following these steps:</p>
+<h3>To transfer these attendance results to Populi, you must first create the Populi attendance record by following these steps:</h3>
 <ol>
   <li>In Populi under My Course -> Attendance, select the corresponding Attendance time slot</li>
   <li>Click the link "All Excused" to give each student a temporary status</li>
@@ -8,4 +9,8 @@
   <li>Scroll to the bottom of the page and click "Save Attendance"</li>
 </ol>
 
-<%= button_to "Transfer Student Attendances to Populi", attendance_populi_transfer_index_path(@attendance), id: "populi-attendance-transfer", class: "s-button" %>
+<%= form_with url: attendance_populi_transfer_index_path(facade.attendance), method: :post do |f| %>
+  <h3>Please select the attendance time slot to transfer to:</h3>
+  <%= f.select :populi_meeting_id, facade.populi_meeting_options, selected: facade.populi_meeting_selection %>
+  <%= f.submit "Transfer Student Attendances to Populi", id: "populi-attendance-transfer", class: "s-button" %>
+<% end %>

--- a/spec/features/attendances/populi_transfer_spec.rb
+++ b/spec/features/attendances/populi_transfer_spec.rb
@@ -11,107 +11,150 @@ RSpec.describe 'Populi Transfer' do
     @test_zoom_meeting_id = 96428502996
 
     stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
-    .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
+      .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
 
     stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_zoom_meeting_id}") \
-    .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))
-    
+      .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))
+
     stub_request(:post, ENV['POPULI_API_URL']).
       with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
       to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings_without_ids.xml'))
+    
+    visit turing_module_path(@mod)
+
+    fill_in :attendance_meeting_url, with:  "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
+                
+    click_button 'Take Attendance'
+
+    @test_attendance = Attendance.last
 
     Sidekiq::Testing.inline!
   end
 
-  context "update successful" do
+  context "user follows instructions to create populi attendance record" do
     before :each do
-      update_response = File.read('spec/fixtures/populi/update_student_attendance_success.xml')
-
-      @update_attendance_stub1 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490140", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-      @update_attendance_stub2 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490130", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-      # Absent
-      @update_attendance_stub3 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490100", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-      # Absent due to tardiness
-      @update_attendance_stub4 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490062", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-      @update_attendance_stub5 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490161", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-      @update_attendance_stub6 = stub_request(:post, ENV['POPULI_API_URL']).         
-        with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490123", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
-        to_return(status: 200, body: update_response) 
-    end
-
-    it 'sends the request to update the students attendance in Populi' do
-      visit turing_module_path(@mod)
-
-      fill_in :attendance_meeting_url, with:  "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
-                  
-      click_button 'Take Attendance'
-
-      test_attendance = Attendance.last
-
-      click_link "Transfer Student Attendances to Populi"
-
-      expect(current_path).to eq("/attendances/#{test_attendance.id}/populi_transfer/new")
-
-      expect(page).to have_content(test_attendance.meeting.title)
-      expect(page).to have_content(pretty_time(test_attendance.attendance_time))
-      expect(page).to have_content(pretty_date(test_attendance.attendance_time))
-      expect(page).to have_content("Tardy: 2")
-      expect(page).to have_content("Present: 2")
-      expect(page).to have_content("Absent: 2")
-
       # Assume that the User has followed instructions to create attendance record in Populi. The corresponding meeting should be returned from the Populi API with a meetingID.
       stub_request(:post, ENV['POPULI_API_URL']).
         with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
         to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))
+      
+    end
 
-      click_button "Transfer Student Attendances to Populi"
+    context "update successful" do
+      it 'sends the request to update the students attendance in Populi' do
+        update_response = File.read('spec/fixtures/populi/update_student_attendance_success.xml')
 
-      expect(current_path).to eq(attendance_path(test_attendance))
+        @update_attendance_stub1 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490140", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub2 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490130", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        # Absent
+        @update_attendance_stub3 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490100", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        # Absent due to tardiness
+        @update_attendance_stub4 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490062", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub5 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490161", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub6 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1962", "personID"=>"24490123", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
 
-      expect(page).to have_content("Transferring attendance to Populi")
+        click_link "Transfer Student Attendances to Populi"
 
-      expect(@update_attendance_stub1).to have_been_requested
-      expect(@update_attendance_stub2).to have_been_requested
-      expect(@update_attendance_stub3).to have_been_requested
-      expect(@update_attendance_stub4).to have_been_requested
-      expect(@update_attendance_stub5).to have_been_requested
-      expect(@update_attendance_stub6).to have_been_requested
+        expect(current_path).to eq("/attendances/#{@test_attendance.id}/populi_transfer/new")
+
+        expect(page).to have_content(@test_attendance.meeting.title)
+        expect(page).to have_content(pretty_time(@test_attendance.attendance_time))
+        expect(page).to have_content(pretty_date(@test_attendance.attendance_time))
+        expect(page).to have_content("Tardy: 2")
+        expect(page).to have_content("Present: 2")
+        expect(page).to have_content("Absent: 2")
+
+        expect(page).to have_select(selected: "9:00 AM")
+
+        click_button "Transfer Student Attendances to Populi"
+
+        expect(current_path).to eq(attendance_path(@test_attendance))
+
+        expect(page).to have_content("Transferring attendance to Populi")
+
+        expect(@update_attendance_stub1).to have_been_requested
+        expect(@update_attendance_stub2).to have_been_requested
+        expect(@update_attendance_stub3).to have_been_requested
+        expect(@update_attendance_stub4).to have_been_requested
+        expect(@update_attendance_stub5).to have_been_requested
+        expect(@update_attendance_stub6).to have_been_requested
+      end    
+
+      it 'can transfer to a different time slot' do
+        update_response = File.read('spec/fixtures/populi/update_student_attendance_success.xml')
+
+        @update_attendance_stub1 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490140", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub2 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490130", "status"=>"PRESENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        # Absent
+        @update_attendance_stub3 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490100", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        # Absent due to tardiness
+        @update_attendance_stub4 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490062", "status"=>"ABSENT", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub5 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490161", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+        @update_attendance_stub6 = stub_request(:post, ENV['POPULI_API_URL']).         
+          with(body: {"instanceID"=>"10547831", "meetingID"=>"1963", "personID"=>"24490123", "status"=>"TARDY", "task"=>"updateStudentAttendance"},).
+          to_return(status: 200, body: update_response) 
+
+        click_link "Transfer Student Attendances to Populi"
+
+        expect(page).to have_select(:populi_meeting_id)
+
+        select("1:00 PM")
+
+        click_button "Transfer Student Attendances to Populi"
+
+        expect(@update_attendance_stub1).to have_been_requested
+        expect(@update_attendance_stub2).to have_been_requested
+        expect(@update_attendance_stub3).to have_been_requested
+        expect(@update_attendance_stub4).to have_been_requested
+        expect(@update_attendance_stub5).to have_been_requested
+        expect(@update_attendance_stub6).to have_been_requested
+      end
+    end
+
+    context "update error" do
+      it 'can handle a failure response from Populi' do
+        stub_request(:post, ENV['POPULI_API_URL']) \
+          .with{|request| request.body.include? "updateStudentAttendance"} \
+          .to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance_error.xml')) 
+
+        visit turing_module_path(@mod)
+
+        fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
+                    
+        click_button 'Take Attendance'
+
+        click_link "Transfer Student Attendances to Populi"
+
+        
+
+        expect {click_button "Transfer Student Attendances to Populi"}.to raise_exception
+      end
     end    
-
-    it 'can transfer to a different time slot'
   end
 
-  context "update error" do
-    it 'can handle a failure response from Populi' do
-      stub_request(:post, ENV['POPULI_API_URL']) \
-        .with{|request| request.body.include? "updateStudentAttendance"} \
-        .to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance_error.xml')) 
+  context "user doesn't follow instructions" do # Populi meeting won't have an id
 
-      visit turing_module_path(@mod)
-
-      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
-                  
-      click_button 'Take Attendance'
-
-      click_link "Transfer Student Attendances to Populi"
-
-      # Assume that the User has followed instructions to create attendance record in Populi. The corresponding meeting should be returned from the Populi API with a meetingID.
-      stub_request(:post, ENV['POPULI_API_URL']).
-        with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
-        to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))
-
-      expect {click_button "Transfer Student Attendances to Populi"}.to raise_exception
-      # click_button "Transfer Student Attendances to Populi"
-    end
   end
 end


### PR DESCRIPTION
__x__ Wrote Tests _x___ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [x ] New feature
- [ ] Bug Fix
- [ ] Refactor

## Description of Change:

When transferring attendance results to populi, user must select the correct attendance time slot. Only time slots on the same day as the meetings are options to prevent user from accidentally transferring to the wrong day. Previously, we were assuming which time slot they were transferring to based on the meeting start time. The selection will still default to the time slot closest to the meeting start time, but user can select a different time slot.

## Requested feedback:

n/a

## Check the correct boxes

- [x ] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [x ] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media0.giphy.com/media/vIpCeF7YcCrygqAn3R/giphy-downsized-medium.gif"/>

