### PR TITLE
Handles sad path when user doesn't follow populi transfer instructions

### DIFF
--- a/app/controllers/user/populi_transfer_controller.rb
+++ b/app/controllers/user/populi_transfer_controller.rb
@@ -6,11 +6,23 @@ class User::PopuliTransferController < User::BaseController
     }
   end
 
+  def time_select
+    attendance = Attendance.find(params[:attendance_id])
+    render locals: {
+      facade: PopuliTransferFacade.new(attendance)
+    }
+  end
+
   def create
     attendance = Attendance.find(params[:attendance_id])
-    PopuliTransferJob.perform_async(attendance.id, params[:populi_meeting_id])
-    flash[:success] = "Transferring attendance to Populi. Please confirm in Populi that #{populi_attendance_link(attendance)} is accurate."
-    redirect_to attendance
+    if params[:populi_meeting_id].blank?
+      flash[:error] = "It looks like that Attendance hasn't been created in Populi yet. Please make sure you are following the directions below to create the Attendance record in Populi before proceeding"
+      redirect_to new_attendance_populi_transfer_path(attendance)
+    else
+      PopuliTransferJob.perform_async(attendance.id, params[:populi_meeting_id])
+      flash[:success] = "Transferring attendance to Populi. Please confirm in Populi that #{populi_attendance_link(attendance)} is accurate."
+      redirect_to attendance
+    end
   end
 
 private

--- a/app/views/user/populi_transfer/new.html.erb
+++ b/app/views/user/populi_transfer/new.html.erb
@@ -9,8 +9,4 @@
   <li>Scroll to the bottom of the page and click "Save Attendance"</li>
 </ol>
 
-<%= form_with url: attendance_populi_transfer_index_path(facade.attendance), method: :post do |f| %>
-  <h3>Please select the attendance time slot to transfer to:</h3>
-  <%= f.select :populi_meeting_id, facade.populi_meeting_options, selected: facade.populi_meeting_selection %>
-  <%= f.submit "Transfer Student Attendances to Populi", id: "populi-attendance-transfer", class: "s-button" %>
-<% end %>
+<%= link_to "I have created the Attendance record in Populi", attendance_populi_transfer_time_select_path(facade.attendance), class: 's-button' %>

--- a/app/views/user/populi_transfer/time_select.html.erb
+++ b/app/views/user/populi_transfer/time_select.html.erb
@@ -1,0 +1,9 @@
+<h1><%= link_to facade.turing_module.name, turing_module_path(facade.turing_module) %></h1>
+<%= render partial: "shared/attendance_details", locals: {attendance: facade.attendance, updatable: false} %>
+<h1>Transfer Student Attendances to Populi</h1>
+
+<%= form_with url: attendance_populi_transfer_index_path(facade.attendance), method: :post do |f| %>
+  <h3>Please select the attendance time slot to transfer to:</h3>
+  <%= f.select :populi_meeting_id, facade.populi_meeting_options, selected: facade.populi_meeting_selection %>
+  <%= f.submit "Transfer Student Attendances to Populi", id: "populi-attendance-transfer", class: "s-button" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :turing_modules, path: '/modules', only: [:show, :create], shallow: true do
       resources :attendances, only: [:create, :show, :edit, :update] do
         resources :populi_transfer, only: [:new, :create, :index]
+        get 'populi_transfer/time_select', to: "populi_transfer#time_select"
         patch "students/:id", to: 'attendances#update_zoom_alias', as: :student
       end
 

--- a/spec/features/attendances/populi_transfer_spec.rb
+++ b/spec/features/attendances/populi_transfer_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Populi Transfer' do
     stub_request(:post, ENV['POPULI_API_URL']).
       with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
       to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings_without_ids.xml'))
+
+    stub_request(:post, ENV['POPULI_API_URL']).
+      with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
+      to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings_without_ids.xml'))  
     
     visit turing_module_path(@mod)
 
@@ -32,14 +36,6 @@ RSpec.describe 'Populi Transfer' do
   end
 
   context "user follows instructions to create populi attendance record" do
-    before :each do
-      # Assume that the User has followed instructions to create attendance record in Populi. The corresponding meeting should be returned from the Populi API with a meetingID.
-      stub_request(:post, ENV['POPULI_API_URL']).
-        with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
-        to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))
-      
-    end
-
     context "update successful" do
       it 'sends the request to update the students attendance in Populi' do
         update_response = File.read('spec/fixtures/populi/update_student_attendance_success.xml')
@@ -75,6 +71,14 @@ RSpec.describe 'Populi Transfer' do
         expect(page).to have_content("Tardy: 2")
         expect(page).to have_content("Present: 2")
         expect(page).to have_content("Absent: 2")
+        
+        # Assume that the User has followed instructions to create attendance record in Populi. 
+        # The corresponding meeting should be returned from the Populi API with a meetingID.
+        stub_request(:post, ENV['POPULI_API_URL']).
+          with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
+          to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))  
+        
+        click_link "I have created the Attendance record in Populi"
 
         expect(page).to have_select(selected: "9:00 AM")
 
@@ -118,6 +122,14 @@ RSpec.describe 'Populi Transfer' do
 
         click_link "Transfer Student Attendances to Populi"
 
+        # Assume that the User has followed instructions to create attendance record in Populi. 
+        # The corresponding meeting should be returned from the Populi API with a meetingID.
+        stub_request(:post, ENV['POPULI_API_URL']).
+          with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@mod.populi_course_id}).
+          to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))  
+        
+        click_link "I have created the Attendance record in Populi"
+
         expect(page).to have_select(:populi_meeting_id)
 
         select("1:00 PM")
@@ -147,14 +159,25 @@ RSpec.describe 'Populi Transfer' do
 
         click_link "Transfer Student Attendances to Populi"
 
-        
-
         expect {click_button "Transfer Student Attendances to Populi"}.to raise_exception
       end
     end    
   end
 
   context "user doesn't follow instructions" do # Populi meeting won't have an id
+    it 'returns them to the populi transfer start page and displays an error' do
+      click_link "Transfer Student Attendances to Populi"
 
+      # Assume that the User has NOT followed instructions to create attendance record in Populi. 
+      # The corresponding meeting should be returned from the Populi API WITHOUT a meetingID.
+      click_link "I have created the Attendance record in Populi"
+
+      select("9:00 AM")
+
+      click_button "Transfer Student Attendances to Populi"
+
+      expect(current_path).to eq(new_attendance_populi_transfer_path(@test_attendance))
+      expect(page).to have_content("It looks like that Attendance hasn't been created in Populi yet. Please make sure you are following the directions below to create the Attendance record in Populi before proceeding")
+    end
   end
 end


### PR DESCRIPTION

__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ x] New feature
- [ x] Bug Fix
- [ ] Refactor

## Description of Change:

Makes Populi transfer a 2 step process
1. User reads instructions for creating the attendance in Populi, and then (hopefully) does them
2. User selects time slot to transfer to

If they follow the instructions from step 1, then the time slot they select in step 2 will correspond to the attendance they created in step 1. 

If they don't follow the instructions, or follow the instructions but for the wrong time slot, then the time slot they select in step 2 will not have a populi meeting id and we do not perform the transfer, instead redirecting them to the start and display an error.

## Requested feedback:

Anything on the UI, the error text, etc. Is this an easy process for the user to follow?

## Check the correct boxes

- [x ] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media3.giphy.com/media/ftSalHoEma5EtzulYE/giphy.gif"/>
