### PR TITLE
Resuses Student data from inning to inning

### DIFF
--- a/app/facades/populi_facade.rb
+++ b/app/facades/populi_facade.rb
@@ -38,10 +38,14 @@ class PopuliFacade
   end 
 
   def import_students
-    # Refactor: Might want to move this
-    self.module.students.destroy_all
-    populi_students.each do |student|
-      self.module.students.create!(name: student.name, populi_id: student.personid)
+    populi_students.each do |populi_student|
+      existing_student = Student.find_by(populi_id: populi_student.personid)
+      if existing_student
+        self.module.students << existing_student
+        existing_student.update(name: populi_student.name) unless populi_student.name == existing_student.name
+      else
+        self.module.students.create(name: populi_student.name, populi_id: populi_student.personid)
+      end
     end
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,5 +1,5 @@
 class Student < ApplicationRecord
-  belongs_to :turing_module, optional: true
+  belongs_to :turing_module
   has_many :student_attendances, dependent: :destroy
   has_many :attendances, through: :student_attendances
   has_many :zoom_aliases

--- a/spec/factories/student.rb
+++ b/spec/factories/student.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :student do
     name { Faker::Name.name }
+    turing_module
 
     factory :setup_student do
-      turing_module
+      sequence(:slack_id) {|n| "<slack_id_#{n}>"}  
       sequence(:populi_id) {|n| "<populi_id_#{n}>"}
-      sequence(:slack_id) {|n| "<slack_id_#{n}>"}
       
       after :create do |student|
         create(:zoom_alias, student: student)

--- a/spec/features/modules/setup/redo_account_match_spec.rb
+++ b/spec/features/modules/setup/redo_account_match_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe "Redo Module Setup Account Matching" do
       click_button "Import Zoom Accounts From Meeting"
 
       click_button 'Connect Accounts'
-      
-      new_lacey_id = Student.find_by(name: "Lacey Weaver").id
 
       # All the student ids that existed before the redo should still exist
       expect(Student.where(id: original_ids).count).to eq(original_ids.length)

--- a/spec/features/modules/setup/redo_account_match_spec.rb
+++ b/spec/features/modules/setup/redo_account_match_spec.rb
@@ -31,28 +31,51 @@ RSpec.describe "Redo Module Setup Account Matching" do
     end 
   
     it 'has option on mod show page to redo mod setup' do 
-        expect(@test_module.students.count).to eq(6) #there are 6 students created from the factory
+      expect(@test_module.students.count).to eq(6) #there are 6 students created from the factory
 
-        visit turing_module_path(@test_module)
-        click_link "Redo Module Setup"
+      visit turing_module_path(@test_module)
+      click_link "Redo Module Setup"
 
-        within '#best-match' do
-            click_button 'Yes'
-        end
+      within '#best-match' do
+        click_button 'Yes'
+      end
 
-        fill_in :slack_channel_id, with: @channel_id
-        click_button "Import Channel"
+      fill_in :slack_channel_id, with: @channel_id
+      click_button "Import Channel"
 
-        fill_in :zoom_meeting_id, with: @zoom_meeting_id
-        click_button "Import Zoom Accounts From Meeting"
+      fill_in :zoom_meeting_id, with: @zoom_meeting_id
+      click_button "Import Zoom Accounts From Meeting"
 
-        click_button 'Connect Accounts'
+      click_button 'Connect Accounts'
 
-        @test_module.reload
-        
-        expect(@test_module.students.count).to eq(7) #there are 7 students in the populi fixture file.
-        expect(current_path).to eq(turing_module_path(@test_module))
-        expect(@test_module.attendances.count).to eq(0)
+      @test_module.reload
+      
+      expect(@test_module.students.count).to eq(7) #there are 7 students in the populi fixture file.
+      expect(current_path).to eq(turing_module_path(@test_module))
+      expect(@test_module.attendances.count).to eq(0)
     end 
+
+    it 'does not destroy student records' do
+      original_lacey_id = Student.find_by(name: "Lacey Weaver").id
+
+      visit turing_module_path(@test_module)
+      click_link "Redo Module Setup"
+
+      within '#best-match' do
+        click_button 'Yes'
+      end
+
+      fill_in :slack_channel_id, with: @channel_id
+      click_button "Import Channel"
+
+      fill_in :zoom_meeting_id, with: @zoom_meeting_id
+      click_button "Import Zoom Accounts From Meeting"
+
+      click_button 'Connect Accounts'
+      
+      new_lacey_id = Student.find_by(name: "Lacey Weaver").id
+
+      expect(new_lacey_id).to eq(original_lacey_id)
+    end
   end
 end

--- a/spec/features/modules/setup/redo_account_match_spec.rb
+++ b/spec/features/modules/setup/redo_account_match_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Redo Module Setup Account Matching" do
     end 
 
     it 'does not destroy student records' do
-      original_lacey_id = Student.find_by(name: "Lacey Weaver").id
+      original_ids = Student.pluck(:id)
 
       visit turing_module_path(@test_module)
       click_link "Redo Module Setup"
@@ -75,7 +75,8 @@ RSpec.describe "Redo Module Setup Account Matching" do
       
       new_lacey_id = Student.find_by(name: "Lacey Weaver").id
 
-      expect(new_lacey_id).to eq(original_lacey_id)
+      # All the student ids that existed before the redo should still exist
+      expect(Student.where(id: original_ids).count).to eq(original_ids.length)
     end
   end
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Student, type: :model do
   end
   
   describe 'relationships' do
-    it {should belong_to(:turing_module).optional}
+    it {should belong_to(:turing_module)}
     it {should have_many :student_attendances}
     it {should have_many(:attendances).through(:student_attendances)}
     it {should have_many(:zoom_aliases)}


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented ___x_ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Previously we were creating new student records each inning. We were also deleting the student records when redoing module setup.

Now: when doing module setup, we'll first check if there is an existing student. If there is, then we just reassign that student to the new module. When redoing the module setup, we don't destroy any student records.

Also makes turing_module required for a student (there shouldn't be any students that aren't part of a module).

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [x ] My code has no binding.pry's
- [x ] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media.tenor.com/qLcAy8rubBAAAAAC/homestar-homestar-runner.gif"/>
