### PR TITLE
Fixes false positive test that was expecting any error to be raised

### DIFF
--- a/app/errors/attendance_update_error.rb
+++ b/app/errors/attendance_update_error.rb
@@ -1,0 +1,2 @@
+class AttendanceUpdateError < StandardError
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -59,7 +59,9 @@ class Attendance < ApplicationRecord
     student_attendances.includes(:student).each do |student_attendance|
       response = service.update_student_attendance(course_id, populi_meeting_id, student_attendance.student.populi_id, student_attendance.status)
       begin
-        raise "Student Attendance not updated" unless response[:response][:result] == "UPDATED"
+        unless response[:response][:result] == "UPDATED"
+          raise AttendanceUpdateError.new("Student: #{student_attendance.student.populi_id}, status: #{student_attendance.status}, response: #{response.to_s}") 
+        end
       rescue => error
         Honeybadger.notify(response.to_s)
         raise error # raise the error anyway so that the job will retry


### PR DESCRIPTION
__x__ Wrote Tests _x___ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [ x] Bug Fix
- [ ] Refactor

## Description of Change:

In populi transfer spec, the test to handle an error response from populi was expecting any error to be raised. This was causing a capybara error to make the test pass, creating a false positive.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [ x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media2.giphy.com/media/mvyvXwL26FfAtRCLPk/giphy.gif"/>
