### PR TITLE
Adds rate limiting for slack presence check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "sidekiq-cron"
 # Debugger and Rails Console
 gem 'pry-rails'
 
+# Rate Limiting
+gem 'ruby-limiter'
+
 group :development, :test do
   gem 'figaro'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    ruby-limiter (2.2.2)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.8.6)
@@ -371,6 +372,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   rspec-rails
+  ruby-limiter
   selenium-webdriver
   shoulda-matchers
   sidekiq (~> 7.1)

--- a/app/models/inning.rb
+++ b/app/models/inning.rb
@@ -15,7 +15,7 @@ class Inning < ApplicationRecord
 
   def check_presence_for_students
     check_time = Time.now
-    students.each_slice(50) do |student_slice|
+    students.each_slice(ENV.fetch("PRESENCE_CHECK_BATCH_SIZE", students.count)) do |student_slice|
       student_slice.each do |student|
         response = SlackApiService.get_presence(student.slack_id)
         if response[:ok]

--- a/app/models/inning.rb
+++ b/app/models/inning.rb
@@ -15,17 +15,15 @@ class Inning < ApplicationRecord
 
   def check_presence_for_students
     check_time = Time.now
-    students.each_slice(ENV.fetch("PRESENCE_CHECK_BATCH_SIZE", students.count)) do |student_slice|
-      student_slice.each do |student|
-        response = SlackApiService.get_presence(student.slack_id)
-        if response[:ok]
-          student.slack_presence_checks.create(presence: response[:presence], check_time: check_time)
-        else
-          # We want to be notified if any API call to get a user's presence fails for any reason
-          Honeybadger.notify("Slack Response: #{response.to_s}, Student Slack ID: #{student.slack_id.to_s}")
-        end 
-      end
-      sleep(1.minute)
+    service = SlackApiService.new
+    students.each do |student|
+      response = service.get_presence(student.slack_id)
+      if response[:ok]
+        student.slack_presence_checks.create(presence: response[:presence], check_time: check_time)
+      else
+        # We want to be notified if any API call to get a user's presence fails for any reason
+        Honeybadger.notify("Slack Response: #{response.to_s}, Student Slack ID: #{student.slack_id.to_s}")
+      end 
     end
   end
 end

--- a/app/models/inning.rb
+++ b/app/models/inning.rb
@@ -15,14 +15,17 @@ class Inning < ApplicationRecord
 
   def check_presence_for_students
     check_time = Time.now
-    students.each do |student|
-      response = SlackApiService.get_presence(student.slack_id)
-      if response[:ok]
-        student.slack_presence_checks.create(presence: response[:presence], check_time: check_time)
-      else
-        # We want to be notified if any API call to get a user's presence fails for any reason
-        Honeybadger.notify("Slack Response: #{response.to_s}, Student Slack ID: #{student.slack_id.to_s}")
-      end 
+    students.each_slice(50) do |student_slice|
+      student_slice.each do |student|
+        response = SlackApiService.get_presence(student.slack_id)
+        if response[:ok]
+          student.slack_presence_checks.create(presence: response[:presence], check_time: check_time)
+        else
+          # We want to be notified if any API call to get a user's presence fails for any reason
+          Honeybadger.notify("Slack Response: #{response.to_s}, Student Slack ID: #{student.slack_id.to_s}")
+        end 
+      end
+      sleep(1.minute)
     end
   end
 end

--- a/app/services/slack_api_service.rb
+++ b/app/services/slack_api_service.rb
@@ -1,5 +1,9 @@
 class SlackApiService 
-  def self.get_presence(user_id)
+  extend Limiter::Mixin
+  # Rate limit users.getPresence api call to 50 requests per minute
+  limit_method :get_presence, rate: 50 
+
+  def get_presence(user_id)
     response = conn.get("users.getPresence") do |req|
       req.params[:user] = user_id
     end
@@ -7,8 +11,8 @@ class SlackApiService
   end
 
 private
-  def self.conn 
-    conn = Faraday.new(
+  def conn 
+    Faraday.new(
       url: 'https://slack.com/api',
       headers: {
         'Content-Type' => 'application/x-www-form-urlencoded',

--- a/app/services/slack_api_service.rb
+++ b/app/services/slack_api_service.rb
@@ -21,7 +21,7 @@ private
     )
   end
 
-  def self.parse_response(response)
+  def parse_response(response)
     JSON.parse(response.body, symbolize_names: true)
   end
 end 


### PR DESCRIPTION
____ Wrote Tests __x__ Implemented ____ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Rate limits the [presence check api calls  ](https://api.slack.com/methods/users.getPresence)

This endpoint is at a Tier 3 Rate limit, so it can handle [50+ requests per minute ](https://api.slack.com/docs/rate-limits#tier_t3). I'm not sure why it's 50+ and not just a hard 50. 

This implementation batches the api calls in groups of 50. In between each batch, the thread sleeps for 1 minute. This amount of delay is probably overkill and we might want to do something more sophisticated in the future. But this should allow us to collect the data we need for now.

## Requested feedback:

Better rate limiting strategies? Gems to implement? Any feedback here is welcome.

## Check the correct boxes

- [x ] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media1.giphy.com/media/7JvlHfd7C2GDr7zfZF/giphy.gif"/>
