### PR TITLE
fixes blank vs nil bug for student slack ids

### DIFF
--- a/app/controllers/user/account_match_controller.rb
+++ b/app/controllers/user/account_match_controller.rb
@@ -20,7 +20,6 @@ class User::AccountMatchController < User::BaseController
       flash[:success] = "#{current_module.name} is now set up. Happy attendance taking!"
       redirect_to current_module
     rescue ActiveRecord::RecordInvalid => error
-      Rails.logger.debug error.message
       flash[:error] = "We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student."
       redirect_to new_turing_module_account_match_path(current_module, zoom_meeting_id: params[:zoom_meeting_id])
     end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -7,7 +7,7 @@ class Student < ApplicationRecord
 
   validates_presence_of :name
 
-  validates_uniqueness_of :slack_id, scope: :turing_module_id, allow_nil: true
+  validates_uniqueness_of :slack_id, scope: :turing_module_id, allow_blank: true
 
   def self.have_slack_ids 
     # REFACTOR

--- a/spec/features/modules/setup/account_match_spec.rb
+++ b/spec/features/modules/setup/account_match_spec.rb
@@ -218,5 +218,25 @@ RSpec.describe "Module Setup Account Matching" do
       expect(current_path).to eq(new_turing_module_account_match_path(@mod))
       expect(page).to have_content("We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student.")
     end
+  
+
+    it 'allows the user to select not in channel for multiple students' do
+      within "#student-#{@anthony_b.id}" do
+        within '.slack-select' do 
+          select "Not In Channel"
+        end
+      end
+      
+      within "#student-#{@j.id}" do
+        within '.slack-select' do 
+          select "Not In Channel"
+        end
+      end
+
+      click_button 'Connect Accounts'
+
+      expect(page).to_not have_content("We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student.")
+      expect(current_path).to eq(turing_module_path(@mod))
+    end
   end
 end


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented ___x_ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Students validate uniqueness of slack ids and allow nils. When submitting the account match form, the slack ids were sent as empty strings which are not nil, so the validation did not allow this, causing an error if no slack account is selected for 2 or more students during account matching.

Fixed by changing `allow_nil: true` to `allow_blank: true` for Student slack id uniqueness validation.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media1.giphy.com/media/GXiasDXfP0j8Q/giphy.gif"/>
