### PR TITLE
resets the module's student's slack ids during account matching

### DIFF
--- a/app/controllers/user/account_match_controller.rb
+++ b/app/controllers/user/account_match_controller.rb
@@ -11,28 +11,32 @@ class User::AccountMatchController < User::BaseController
   end 
 
   def create
-    current_module.attendances.destroy_all #if this is a redo
-    failure = false
-    params[:student].each do |student_id, ids|
-      begin
-        Student.update!(student_id, {slack_id: ids[:slack_id]})
-        ZoomAlias.create(name: ids[:zoom_id], student_id: student_id)
-      rescue ActiveRecord::RecordInvalid => error
-        failure = true
-        Rails.logger.warn "Got this error: #{error.message}\nIDs: #{ids}\nstudent: #{student_id} "
-        flash[:error] = "We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student."
-        redirect_to new_turing_module_account_match_path(current_module, zoom_meeting_id: params[:zoom_meeting_id])
-        break
-      end
-    end
-    unless failure
+    current_module.students.update_all(slack_id: nil)
+    if process_account_match_form
       flash[:success] = "#{current_module.name} is now set up. Happy attendance taking!"
       redirect_to current_module
+    else
+      flash[:error] = "We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student."
+      redirect_to new_turing_module_account_match_path(current_module, zoom_meeting_id: params[:zoom_meeting_id])
     end
   end
 
 private
   def current_module
     @current_module ||= TuringModule.find(params[:turing_module_id])
+  end
+
+  def process_account_match_form
+    success = true
+    params[:student].each do |student_id, ids|
+      begin
+        Student.update!(student_id, {slack_id: ids[:slack_id]})
+        ZoomAlias.create(name: ids[:zoom_id], student_id: student_id)
+      rescue ActiveRecord::RecordInvalid => error
+        success = false
+        Rails.logger.warn "Got this error: #{error.message}\nIDs: #{ids}\nstudent: #{student_id}"
+      end
+    end
+    return success
   end
 end 

--- a/spec/features/modules/setup/account_match_spec.rb
+++ b/spec/features/modules/setup/account_match_spec.rb
@@ -238,5 +238,50 @@ RSpec.describe "Module Setup Account Matching" do
       expect(page).to_not have_content("We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student.")
       expect(current_path).to eq(turing_module_path(@mod))
     end
+
+    it 'can correct a mistake if a user selects the wrong slack account for a student' do
+      within "#student-#{@anthony_b.id}" do
+        within '.slack-select' do 
+          select "J Seymour" # User accidentally selects the wrong student
+        end
+      end
+      
+      within "#student-#{@j.id}" do
+        within '.slack-select' do 
+          select "Anthony Blackwell Tallent" # User accidentally selects the wrong student
+        end
+      end
+
+      click_button 'Connect Accounts'
+
+      click_link "Redo Module Setup"
+
+      within '#best-match' do
+        click_button 'Yes'
+      end
+
+      fill_in :slack_channel_id, with: @channel_id
+      click_button "Import Channel"
+
+      fill_in :zoom_meeting_id, with: @zoom_meeting_id
+      click_button "Import Zoom Accounts From Meeting"
+
+      within "#student-#{@anthony_b.id}" do
+        within '.slack-select' do 
+          select "Anthony Blackwell Tallent"
+        end
+      end
+      
+      within "#student-#{@j.id}" do
+        within '.slack-select' do 
+          select "J Seymour"
+        end
+      end
+
+      click_button 'Connect Accounts'
+      
+      expect(page).to_not have_content("We're sorry, something isn't quite working. Make sure you are assigning a different Slack User for each student.")
+      expect(current_path).to eq(turing_module_path(@mod))
+    end
   end
 end


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [ x] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

If a user selects the wrong slack id for a student during account matching, they are blocked from fixing this mistake in a redo of the setup because of the uniqueness constraint on slack ids. This PR fixes that by resetting all of the module's student slack ids before completing the account matching.

## Requested feedback:



## Check the correct boxes

- [ xx] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [x] I have reviewed my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

<img src="https://media1.giphy.com/media/13Cmju3maIjStW/giphy.gif"/>
