### PR TITLE
Valid zoom link

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -349,6 +351,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/user/attendances_controller.rb
+++ b/app/controllers/user/attendances_controller.rb
@@ -1,4 +1,5 @@
 class User::AttendancesController < User::BaseController
+  
   def create
     turing_module = TuringModule.find(params[:turing_module_id])
     begin
@@ -6,6 +7,9 @@ class User::AttendancesController < User::BaseController
       redirect_to attendance_path(attendance)
     rescue InvalidMeetingError => error
       flash[:error] = error.message
+      redirect_to request.referrer
+    rescue URI::InvalidURIError => error
+      flash[:error] = ZoomMeeting.invalid_error
       redirect_to request.referrer
     end
   end

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -60,14 +60,6 @@ private
     InvalidMeetingError.new("It looks like that Zoom link is for a Personal Meeting Room. You will need to use a unique meeting instead.")
   end
 
-  def self.invalid_zoom_url_error
-    InvalidMeetingError.new("The Zoom URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
-  end
-
-  def self.invalid_meeting_id_length_zoom_url_error
-    InvalidMeetingError.new("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
-  end
-
   def participant_report
     @report ||= ZoomService.participant_report(self.meeting_id)[:participants]
   end

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -9,9 +9,6 @@ class ZoomMeeting < Meeting
       raise invalid_zoom_url_error if meeting_id.include?(" ")
       raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
     end
-    #raise errors here 
-    #one for invalid link that has spaces
-    #one for invalid link that has less than or more than 11 characters in meeting id
     meeting_details = ZoomService.meeting_details(meeting_id)    
     raise invalid_error if meeting_details[:code] == 3001
     raise no_meeting_error if meeting_details[:code] == 2300

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -6,6 +6,7 @@ class ZoomMeeting < Meeting
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
     raise invalid_zoom_url_error if meeting_url.include?(" ")
+    raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
     #raise errors here 
     #one for invalid link that has spaces
     #one for invalid link that has less than or more than 11 characters in meeting id
@@ -62,6 +63,10 @@ private
 
   def self.invalid_zoom_url_error
     InvalidMeetingError.new("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+  end
+
+  def self.invalid_meeting_id_length_zoom_url_error
+    InvalidMeetingError.new("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
   end
 
   def participant_report

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -5,8 +5,10 @@ class ZoomMeeting < Meeting
 
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
-    raise invalid_zoom_url_error if meeting_id.match(/\D/)
-    raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
+    if !meeting_id.nil?
+      raise invalid_zoom_url_error if meeting_id.include?(" ")
+      raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
+    end
     #raise errors here 
     #one for invalid link that has spaces
     #one for invalid link that has less than or more than 11 characters in meeting id
@@ -62,11 +64,11 @@ private
   end
 
   def self.invalid_zoom_url_error
-    InvalidMeetingError.new("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+    InvalidMeetingError.new("The Zoom URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
   end
 
   def self.invalid_meeting_id_length_zoom_url_error
-    InvalidMeetingError.new("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+    InvalidMeetingError.new("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
   end
 
   def participant_report

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -5,11 +5,8 @@ class ZoomMeeting < Meeting
 
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
-    # if !meeting_id.nil?
-    #   raise invalid_zoom_url_error if meeting_id.include?(" ")
-    #   raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
-    # end
     meeting_details = ZoomService.meeting_details(meeting_id)    
+    
     raise invalid_error if meeting_details[:code] == 3001
     raise no_meeting_error if meeting_details[:code] == 2300
     raise personal_meeting_error if meeting_details[:start_time].nil?

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -5,10 +5,10 @@ class ZoomMeeting < Meeting
 
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
-    if !meeting_id.nil?
-      raise invalid_zoom_url_error if meeting_id.include?(" ")
-      raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
-    end
+    # if !meeting_id.nil?
+    #   raise invalid_zoom_url_error if meeting_id.include?(" ")
+    #   raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
+    # end
     meeting_details = ZoomService.meeting_details(meeting_id)    
     raise invalid_error if meeting_details[:code] == 3001
     raise no_meeting_error if meeting_details[:code] == 2300

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -5,7 +5,7 @@ class ZoomMeeting < Meeting
 
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
-    raise invalid_zoom_url_error if meeting_url.include?(" ")
+    raise invalid_zoom_url_error if meeting_id.match(/\D/)
     raise invalid_meeting_id_length_zoom_url_error if meeting_id.length < 10 || meeting_id.length > 11
     #raise errors here 
     #one for invalid link that has spaces

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -5,6 +5,10 @@ class ZoomMeeting < Meeting
 
   def self.from_meeting_details(meeting_url)
     meeting_id = meeting_url.split("/").last
+    raise invalid_zoom_url_error if meeting_url.include?(" ")
+    #raise errors here 
+    #one for invalid link that has spaces
+    #one for invalid link that has less than or more than 11 characters in meeting id
     meeting_details = ZoomService.meeting_details(meeting_id)    
     raise invalid_error if meeting_details[:code] == 3001
     raise no_meeting_error if meeting_details[:code] == 2300
@@ -54,6 +58,10 @@ private
 
   def self.personal_meeting_error
     InvalidMeetingError.new("It looks like that Zoom link is for a Personal Meeting Room. You will need to use a unique meeting instead.")
+  end
+
+  def self.invalid_zoom_url_error
+    InvalidMeetingError.new("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
   end
 
   def participant_report

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,19 +22,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
     t.datetime "attendance_time", precision: nil
     t.string "meeting_type"
     t.bigint "meeting_id"
-    t.datetime "end_time"
     t.index ["meeting_type", "meeting_id"], name: "index_attendances_on_meeting_type_and_meeting_id"
     t.index ["turing_module_id"], name: "index_attendances_on_turing_module_id"
     t.index ["user_id"], name: "index_attendances_on_user_id"
-  end
-
-  create_table "inactive_periods", force: :cascade do |t|
-    t.bigint "student_id", null: false
-    t.datetime "start_time"
-    t.datetime "end_time"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["student_id"], name: "index_inactive_periods_on_student_id"
   end
 
   create_table "innings", force: :cascade do |t|
@@ -125,7 +115,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
 
   add_foreign_key "attendances", "turing_modules"
   add_foreign_key "attendances", "users"
-  add_foreign_key "inactive_periods", "students"
   add_foreign_key "slack_presence_checks", "students"
   add_foreign_key "student_attendances", "attendances"
   add_foreign_key "student_attendances", "students"

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -111,5 +111,24 @@ RSpec.describe 'Creating a Zoom Attendance' do
       expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
     end
 
+    it "Shows an error message if the meting ID in the URL is less than 10." do
+      test_module = create(:setup_module)
+      visit turing_module_path(test_module)
+
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789"
+      click_button 'Take Attendance'
+
+      expect(page).to have_content("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+    end
+
+    it "Shows an error message if the meting ID in the URL is greater than 11." do
+      test_module = create(:setup_module)
+      visit turing_module_path(test_module)
+
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789012"
+      click_button 'Take Attendance'
+
+      expect(page).to have_content("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+    end
   end
 end

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
   context "With invalid ids" do
     before :each do
-      @invalid_zoom_id = 'InvalidID'
+      @invalid_zoom_id = 'InvalidID_'
     end
 
     it 'shows a message if an invalid meeting id is entered' do
@@ -108,17 +108,7 @@ RSpec.describe 'Creating a Zoom Attendance' do
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_url 1 2 3"
       click_button 'Take Attendance'
 
-      expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
-    end
-
-    it "Shows an error message if the meeting ID in the URL contains letters or special characters" do
-      test_module = create(:setup_module)
-      visit turing_module_path(test_module)
-
-      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_u*!"
-      click_button 'Take Attendance'
-
-      expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+      expect(page).to have_content("The Zoom URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
     end
 
     it "Shows an error message if the meeting ID in the URL is less than 10." do
@@ -128,17 +118,17 @@ RSpec.describe 'Creating a Zoom Attendance' do
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789"
       click_button 'Take Attendance'
 
-      expect(page).to have_content("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+      expect(page).to have_content("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
     end
 
-    it "Shows an error message if the meting ID in the URL is greater than 11." do
+    it "Shows an error message if the meeting ID in the URL is greater than 11." do
       test_module = create(:setup_module)
       visit turing_module_path(test_module)
 
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789012"
       click_button 'Take Attendance'
 
-      expect(page).to have_content("The URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+      expect(page).to have_content("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
     end
   end
 end

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -108,27 +108,17 @@ RSpec.describe 'Creating a Zoom Attendance' do
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_url 1 2 3"
       click_button 'Take Attendance'
 
-      expect(page).to have_content("The Zoom URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+      expect(page).to have_content("It appears you have entered an invalid Zoom Meeting ID. Please double check the Meeting ID and try again.")
     end
 
-    it "Shows an error message if the meeting ID in the URL is less than 10." do
+    it "Shows an error message if the meeting ID in the URL is missing digits." do
       test_module = create(:setup_module)
       visit turing_module_path(test_module)
 
-      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789"
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/9634435576"
       click_button 'Take Attendance'
 
-      expect(page).to have_content("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
-    end
-
-    it "Shows an error message if the meeting ID in the URL is greater than 11." do
-      test_module = create(:setup_module)
-      visit turing_module_path(test_module)
-
-      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/123456789012"
-      click_button 'Take Attendance'
-
-      expect(page).to have_content("The Zoom URL entered is not valid. Check that the meeting ID has 10-11 digits.")
+      expect(page).to have_content("It appears you have entered an invalid Zoom Meeting ID. Please double check the Meeting ID and try again.")
     end
   end
 end

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -99,4 +99,17 @@ RSpec.describe 'Creating a Zoom Attendance' do
       expect(page).to have_content("It looks like that Zoom link is for a Personal Meeting Room. You will need to use a unique meeting instead.")
     end
   end
+
+  context "With invalid Zoom URLs" do
+    it "Shows an error message if the URL isn't continous, has spaces" do
+      test_module = create(:setup_module)
+      visit turing_module_path(test_module)
+
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_url 1 2 3"
+      click_button 'Take Attendance'
+
+      expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+    end
+
+  end
 end

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Creating a Zoom Attendance' do
       visit turing_module_path(test_module)
 
       click_button 'Take Attendance'
-
+      
       expect(current_path).to eq(turing_module_path(test_module))
       expect(page).to have_content("Please enter a Zoom or Slack link.")
     end
@@ -110,12 +110,12 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/92831928801 928 319 288 01"
       click_button 'Take Attendance'
-
+      
       expect(page).to have_content("It appears you have entered an invalid Zoom Meeting ID. Please double check the Meeting ID and try again.")
     end
 
     it "Shows an error message if the meeting ID in the URL is missing digits." do
-      stub_request(:get, "https://api.zoom.us/v2/meetings/9634435576}") \
+      stub_request(:get, "https://api.zoom.us/v2/meetings/9634435576") \
       .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
 
       test_module = create(:setup_module)

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
   context "With invalid ids" do
     before :each do
-      @invalid_zoom_id = 'InvalidID_'
+      @invalid_zoom_id = 'InvalidID'
     end
 
     it 'shows a message if an invalid meeting id is entered' do
@@ -102,16 +102,22 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
   context "With invalid Zoom URLs" do
     it "Shows an error message if the URL isn't continous, has spaces" do
+      stub_request(:get, "https://api.zoom.us/v2/meetings/92831928801 928 319 288 01") \
+      .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
+
       test_module = create(:setup_module)
       visit turing_module_path(test_module)
 
-      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_url 1 2 3"
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/92831928801 928 319 288 01"
       click_button 'Take Attendance'
 
       expect(page).to have_content("It appears you have entered an invalid Zoom Meeting ID. Please double check the Meeting ID and try again.")
     end
 
     it "Shows an error message if the meeting ID in the URL is missing digits." do
+      stub_request(:get, "https://api.zoom.us/v2/meetings/9634435576}") \
+      .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
+
       test_module = create(:setup_module)
       visit turing_module_path(test_module)
 

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -111,7 +111,17 @@ RSpec.describe 'Creating a Zoom Attendance' do
       expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
     end
 
-    it "Shows an error message if the meting ID in the URL is less than 10." do
+    it "Shows an error message if the meeting ID in the URL contains letters or special characters" do
+      test_module = create(:setup_module)
+      visit turing_module_path(test_module)
+
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/invalid_u*!"
+      click_button 'Take Attendance'
+
+      expect(page).to have_content("The URL entered is not valid. Please enter a URL that follows this format: 'https://turingschool.zoom.us/j/12345678901'.")
+    end
+
+    it "Shows an error message if the meeting ID in the URL is less than 10." do
       test_module = create(:setup_module)
       visit turing_module_path(test_module)
 


### PR DESCRIPTION
__x__ Wrote Tests ____ Implemented ____ Reviewed

## Necessary checkmarks:

- [ x] All Tests are Passing in all environments

- [ x] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

    description: Implements solution for rescuing from a `URI::InvalidURIError` when taking attendance from a zoom meeting link. The error was being raised before the ZoomService could return a JSON package.

## Requested feedback:

    I'd like feedback on my approach to implement the story. I chose to raise the errors before the ZoomService is called since I didn't see any error codes in Zoom's documentation that would address the concerns outlined in the user story. This approach also didn't change the errors that were already being raised.

With the new solution, I'd love to hear more about how it was implemented. The rescue was added to an existing rescue block. Is that the best practice?

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link: https://giphy.com/gifs/old-man-1uC8xfkZRi7Kw
