### PR TITLE
Add duration to student attendances

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -22,7 +22,7 @@ class Attendance < ApplicationRecord
       student = meeting.find_student_from_participant(participant)
       next if student.nil?
       student_attendance = student_attendances.find_or_create_by(student: student)
-      student_attendance.update(duration: participant.duration) if participant.class == ZoomParticipant
+      student_attendance.update(duration: participant.duration)
       participant.assign_status!(attendance_time)
       if student_attendance.record_status_for_participant!(participant)
         meeting.connect_alias(student_attendance, participant.name) if meeting.respond_to? :zoom_aliases

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -22,6 +22,7 @@ class Attendance < ApplicationRecord
       student = meeting.find_student_from_participant(participant)
       next if student.nil?
       student_attendance = student_attendances.find_or_create_by(student: student)
+      student_attendance.update(duration: participant.duration) if participant.class == ZoomParticipant
       participant.assign_status!(attendance_time)
       if student_attendance.record_status_for_participant!(participant)
         meeting.connect_alias(student_attendance, participant.name) if meeting.respond_to? :zoom_aliases
@@ -33,7 +34,7 @@ class Attendance < ApplicationRecord
     student_ids = student_attendances.pluck(:student_id)
     absent_students = turing_module.students.where.not(id: student_ids)
     absent_students.each do |student|
-      student_attendances.create(student: student, status: "absent")
+      student_attendances.create(student: student, status: "absent", duration: "0%")
     end
   end
 

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -34,7 +34,7 @@ class Attendance < ApplicationRecord
     student_ids = student_attendances.pluck(:student_id)
     absent_students = turing_module.students.where.not(id: student_ids)
     absent_students.each do |student|
-      student_attendances.create(student: student, status: "absent", duration: "0%")
+      student_attendances.create(student: student, status: "absent", duration: 0)
     end
   end
 

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -82,7 +82,6 @@ private
   end
 
   def calculate_duration(participant_records) 
-    meeting_duration = self.duration * 60
-    ((participant_records.sum(&:duration).to_f/meeting_duration) * 100 ).round
+    ((participant_records.sum(&:duration).to_f) / 60 ).round
   end 
 end

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -12,7 +12,8 @@ class ZoomMeeting < Meeting
     create(
       meeting_id: meeting_id, 
       start_time: meeting_details[:start_time].to_datetime, 
-      title: meeting_details[:topic]
+      title: meeting_details[:topic],
+      duration: (meeting_details[:duration])
     )
   end
 
@@ -74,7 +75,14 @@ private
   def uniq_participants_best_time(participants)
     grouped_by_name = participants.group_by(&:name)
     participants_best_time = grouped_by_name.map do |name, participant_records|
-      participant_records.min_by(&:join_time)
+      earliest_join_time = participant_records.min_by(&:join_time)
+      earliest_join_time.duration = calculate_duration(participant_records)
+      earliest_join_time
     end
   end
+
+  def calculate_duration(participant_records) 
+    meeting_duration = self.duration * 60
+    ((participant_records.sum(&:duration).to_f/meeting_duration) * 100 ).round
+  end 
 end

--- a/app/poros/slack_thread_participant.rb
+++ b/app/poros/slack_thread_participant.rb
@@ -21,6 +21,6 @@ class SlackThreadParticipant
   end
 
   def duration
-    0
+    nil
   end
 end

--- a/app/poros/slack_thread_participant.rb
+++ b/app/poros/slack_thread_participant.rb
@@ -19,4 +19,8 @@ class SlackThreadParticipant
       @status = 'present' 
     end
   end
+
+  def duration
+    0
+  end
 end

--- a/app/poros/zoom_participant.rb
+++ b/app/poros/zoom_participant.rb
@@ -1,5 +1,6 @@
 class ZoomParticipant
   attr_reader :status, :join_time, :name
+  attr_accessor :duration
 
   ZOOM_TARDY_GRACE_PERIOD_IN_MINUTES = 1
   ZOOM_ABSENT_GRACE_PERIOD_IN_MINUTES = 30
@@ -8,6 +9,7 @@ class ZoomParticipant
     @join_time = Time.parse(participant_data[:join_time])
     @name = participant_data[:name]
     @status = participant_data[:attendance_status]
+    @duration = participant_data[:duration]
   end
 
   def assign_status!(attendance_time)

--- a/app/views/shared/_zoom_attendance_table.html.erb
+++ b/app/views/shared/_zoom_attendance_table.html.erb
@@ -5,6 +5,7 @@
       <th>Student</th>
       <th>Join Time</th>
       <th>Status</th>
+      <th>Duration</th>
       <th>Zoom Alias Used</th>
       <th>Save a new Zoom Alias</th>
     </tr>
@@ -20,6 +21,7 @@
             <td>N/A</td>
           <% end %>
           <td class='<%= student_attendance.status %>'><%= student_attendance.status %></td>
+          <td><%= student_attendance.duration %>%</td>
 
           <% if student_attendance.absent? %>
             <td class="alias-used">N/A</td>

--- a/app/views/shared/_zoom_attendance_table.html.erb
+++ b/app/views/shared/_zoom_attendance_table.html.erb
@@ -5,7 +5,7 @@
       <th>Student</th>
       <th>Join Time</th>
       <th>Status</th>
-      <th>Duration</th>
+      <th>Duration (minutes)</th>
       <th>Zoom Alias Used</th>
       <th>Save a new Zoom Alias</th>
     </tr>
@@ -21,7 +21,7 @@
             <td>N/A</td>
           <% end %>
           <td class='<%= student_attendance.status %>'><%= student_attendance.status %></td>
-          <td><%= student_attendance.duration %>%</td>
+          <td><%= student_attendance.duration %></td>
 
           <% if student_attendance.absent? %>
             <td class="alias-used">N/A</td>

--- a/db/migrate/20230726035154_add_duration_to_student_attendances.rb
+++ b/db/migrate/20230726035154_add_duration_to_student_attendances.rb
@@ -1,0 +1,5 @@
+class AddDurationToStudentAttendances < ActiveRecord::Migration[7.0]
+  def change
+    add_column :student_attendances, :duration, :integer
+  end
+end

--- a/db/migrate/20230726040041_add_duration_to_zoom_meetings.rb
+++ b/db/migrate/20230726040041_add_duration_to_zoom_meetings.rb
@@ -1,0 +1,5 @@
+class AddDurationToZoomMeetings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :zoom_meetings, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_035154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,19 +22,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
     t.datetime "attendance_time", precision: nil
     t.string "meeting_type"
     t.bigint "meeting_id"
-    t.datetime "end_time"
     t.index ["meeting_type", "meeting_id"], name: "index_attendances_on_meeting_type_and_meeting_id"
     t.index ["turing_module_id"], name: "index_attendances_on_turing_module_id"
     t.index ["user_id"], name: "index_attendances_on_user_id"
-  end
-
-  create_table "inactive_periods", force: :cascade do |t|
-    t.bigint "student_id", null: false
-    t.datetime "start_time"
-    t.datetime "end_time"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["student_id"], name: "index_inactive_periods_on_student_id"
   end
 
   create_table "innings", force: :cascade do |t|
@@ -67,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "zoom_alias_id"
+    t.integer "duration"
     t.index ["attendance_id"], name: "index_student_attendances_on_attendance_id"
     t.index ["student_id"], name: "index_student_attendances_on_student_id"
     t.index ["zoom_alias_id"], name: "index_student_attendances_on_zoom_alias_id"
@@ -125,7 +116,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_205940) do
 
   add_foreign_key "attendances", "turing_modules"
   add_foreign_key "attendances", "users"
-  add_foreign_key "inactive_periods", "students"
   add_foreign_key "slack_presence_checks", "students"
   add_foreign_key "student_attendances", "attendances"
   add_foreign_key "student_attendances", "students"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_26_035154) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_040041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -112,6 +112,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_26_035154) do
     t.string "meeting_id"
     t.string "title"
     t.datetime "start_time", precision: nil
+    t.integer "duration"
   end
 
   add_foreign_key "attendances", "turing_modules"

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
       click_button 'Take Attendance'
-      save_and_open_page
+
       expect(current_path).to eq(attendance_path(Attendance.last))
       expect(page).to have_css('.student-attendance', count: @test_module.students.count)
       expect(find("#student-attendances")).to have_table_row("Student" => absent.name, "Status" => 'absent', "Duration" => "0")

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
       fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
       click_button 'Take Attendance'
-
+      save_and_open_page
       expect(current_path).to eq(attendance_path(Attendance.last))
       expect(page).to have_css('.student-attendance', count: @test_module.students.count)
-      expect(find("#student-attendances")).to have_table_row("Student" => absent.name, "Status" => 'absent', "Duration" => "0%")
-      expect(find("#student-attendances")).to have_table_row("Student" => absent_due_to_tardiness.name, "Status" => 'absent', "Duration" => "85%")
-      expect(find("#student-attendances")).to have_table_row("Student" => tardy.name, "Status" => 'tardy', "Duration" => "78%")
-      expect(find("#student-attendances")).to have_table_row("Student" => present.name, "Status" => 'present', "Duration" => "81%")
+      expect(find("#student-attendances")).to have_table_row("Student" => absent.name, "Status" => 'absent', "Duration" => "0")
+      expect(find("#student-attendances")).to have_table_row("Student" => absent_due_to_tardiness.name, "Status" => 'absent', "Duration" => "63")
+      expect(find("#student-attendances")).to have_table_row("Student" => tardy.name, "Status" => 'tardy', "Duration" => "59")
+      expect(find("#student-attendances")).to have_table_row("Student" => present.name, "Status" => 'present', "Duration" => "61")
     end
 
   end

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -47,11 +47,12 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
       expect(current_path).to eq(attendance_path(Attendance.last))
       expect(page).to have_css('.student-attendance', count: @test_module.students.count)
-      expect(find("#student-attendances")).to have_table_row("Student" => absent.name, "Status" => 'absent')
-      expect(find("#student-attendances")).to have_table_row("Student" => absent_due_to_tardiness.name, "Status" => 'absent')
-      expect(find("#student-attendances")).to have_table_row("Student" => tardy.name, "Status" => 'tardy')
-      expect(find("#student-attendances")).to have_table_row("Student" => present.name, "Status" => 'present')
+      expect(find("#student-attendances")).to have_table_row("Student" => absent.name, "Status" => 'absent', "Duration" => "0%")
+      expect(find("#student-attendances")).to have_table_row("Student" => absent_due_to_tardiness.name, "Status" => 'absent', "Duration" => "85%")
+      expect(find("#student-attendances")).to have_table_row("Student" => tardy.name, "Status" => 'tardy', "Duration" => "78%")
+      expect(find("#student-attendances")).to have_table_row("Student" => present.name, "Status" => 'present', "Duration" => "81%")
     end
+
   end
 
   context "With invalid ids" do


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [x] New feature
- [ ] Bug Fix
- [ ] Refactor

## Description of Change:

    description: This is not a current issue/card, but I thought it would be nice to see duration of time that a student is in class. So, this PR adds duration columns to the student_attendances and the zoom_meetings tables, and displays the student's duration on the attendance show page. 

## Requested feedback:

    I'd like feedback in two places -- I currently have the bulk of this logic in the ZoomMeeting PORO in the `uniq_participants_best_time`. I'm sure I could probably refactor this, but curious on your thoughts around it first. And secondly, to get around slack attendances not having a duration, I only set duration if the polymorphic `meeting` in the Attendance class is a ZoomMeeting... how do you feel about that approach?

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link: https://media.tenor.com/sf5HpJ9vlY0AAAAC/exciting-to-be-back-here-its-good-to-be-back.gif
