### PR TITLE
Add styles to slack pagination

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,10 +13,36 @@
  *= require_tree .
  *= require_self
  */
+
+.pagination {
+  margin: 20px;
+}
+
+.pagination span {
+  border: 1px solid #DDD;
+  border-radius: 5px;
+  display: inline-block;
+  font-size: 24px;
+  margin: 5px;
+  padding: 10px;
+  transition: background-color .3s;
+}
+
+.pagination span:hover:not(.current) {
+  background-color: #ddd;
+}
+
+
+.pagination .current {
+  background-color: #4d4d4f;
+  color: #FFF;
+}
+
 #take-attendance {
   margin-bottom: 20px;
   margin-top: 20px;
 }
+
 .my-mod-button {
   margin-bottom: 2%;
 }


### PR DESCRIPTION
____ Wrote Tests X Implemented ____ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [x] New feature
- [ ] Bug Fix
- [ ] Refactor

## Description of Change:

I've updated to the styling so that as an admin, when you visit `/admin/slack_presence_checks`, the pagination links are styled.  See screenshot below:

<img width="710" alt="Screenshot 2023-08-24 at 8 33 06 AM" src="https://github.com/turingschool/present/assets/25714149/bd390efd-572f-4b7e-b828-f429bf588177">


## Requested feedback:

 Curious to hear thoughts on spacing and colors.  Also I noticed, since I have styled these links more as buttons, the "click" still has to happen on the words itself.  If you attempt to click the button and not the text, it won't work.  This would require changing the structure of the HTML, is this something we want to do or should we just leave it for now?

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link: https://media.giphy.com/media/l2Sq29cFXoF80ADlK/giphy.gif
