### PR TITLE
Redoing module setup will remove previous students

### DIFF
--- a/app/facades/populi_facade.rb
+++ b/app/facades/populi_facade.rb
@@ -24,15 +24,11 @@ class PopuliFacade
   end
 
   def import_students
-    populi_students.each do |populi_student|
-      existing_student = Student.find_by(populi_id: populi_student.personid)
-      if existing_student
-        self.module.students << existing_student
-        existing_student.update(name: populi_student.name) unless populi_student.name == existing_student.name
-      else
-        self.module.students.create(name: populi_student.name, populi_id: populi_student.personid)
-      end
+    @module.students.update_all(turing_module_id: nil)
+    student_attributes = populi_students.map do |populi_student|
+      {name: populi_student.name, populi_id: populi_student.personid, turing_module_id: @module.id}
     end
+    Student.upsert_all(student_attributes, unique_by: :populi_id)
   end
 
   def term_options

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -9,6 +9,8 @@ class Student < ApplicationRecord
 
   validates_uniqueness_of :slack_id, scope: :turing_module_id, allow_blank: true
 
+  validates_uniqueness_of :populi_id, allow_blank: true
+
   def self.have_slack_ids 
     # REFACTOR
     !Student.where.not(slack_id: nil).empty?

--- a/db/migrate/20230926165406_students_are_unique_by_populi_id.rb
+++ b/db/migrate/20230926165406_students_are_unique_by_populi_id.rb
@@ -1,0 +1,5 @@
+class StudentsAreUniqueByPopuliId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :students, :populi_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_20_205547) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_165406) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_20_205547) do
     t.bigint "turing_module_id"
     t.string "slack_id"
     t.string "populi_id"
+    t.index ["populi_id"], name: "index_students_on_populi_id", unique: true
     t.index ["turing_module_id"], name: "index_students_on_turing_module_id"
   end
 

--- a/spec/factories/turing_module.rb
+++ b/spec/factories/turing_module.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     module_number { 3 }
     inning
 
-    factory :setup_module do
+    factory :setup_module do # Can only have one setup_module per test because students must be unique by populi_id
       module_number {3}
       program {:BE} 
       populi_course_id {10547831}

--- a/spec/features/attendances/create_slack_attendance_spec.rb
+++ b/spec/features/attendances/create_slack_attendance_spec.rb
@@ -61,19 +61,5 @@ RSpec.describe 'Creating an Attendance' do
       expect(find("#student-attendances")).to have_table_row("Student" => tardy.name, "Status" => 'tardy')
       expect(find("#student-attendances")).to have_table_row("Student" => present.name, "Status" => 'present')
     end
-
-    it 'does not find a student from a different module' do
-      other_inning = create(:inning, current: false)
-      other_module = create(:setup_module, inning: other_inning)
-      @test_module = create(:setup_module)
-      slack_url = "https://turingschool.slack.com/archives/C02HRH7MF5K/p1672861516089859"
-
-      visit turing_module_path(@test_module)
-
-      fill_in :attendance_meeting_url, with: slack_url
-      click_button 'Take Attendance'
-
-      expect(page).to have_css('.student-attendance', count: @test_module.students.count)
-    end
   end
 end 

--- a/spec/features/modules/setup/redo_account_match_spec.rb
+++ b/spec/features/modules/setup/redo_account_match_spec.rb
@@ -82,5 +82,29 @@ RSpec.describe "Redo Module Setup Account Matching" do
       # All the student ids that existed before the redo should still exist
       expect(Student.where(id: original_ids).count).to eq(original_ids.length)
     end
+
+    it 'removes any students that were part of the module before the redo' do
+      new_student = create(:student)
+
+      @test_module.students << new_student
+
+      visit turing_module_path(@test_module)
+
+      click_link "Redo Module Setup"
+
+      within '#best-match' do
+        click_button 'Yes'
+      end
+
+      fill_in :slack_channel_id, with: @channel_id
+      click_button "Import Channel"
+
+      fill_in :zoom_meeting_id, with: @zoom_meeting_id
+      click_button "Import Zoom Accounts From Meeting"
+
+      click_button 'Connect Accounts'
+
+      expect(@test_module.students).to_not include(new_student)
+    end
   end
 end

--- a/spec/features/modules/setup/redo_account_match_spec.rb
+++ b/spec/features/modules/setup/redo_account_match_spec.rb
@@ -58,14 +58,12 @@ RSpec.describe "Redo Module Setup Account Matching" do
       expect(@test_module.attendances.count).to eq(0)
     end 
 
-    it 'does not destroy student records', js: true do
+    it 'does not destroy student records' do
       original_ids = Student.pluck(:id)
 
       visit turing_module_path(@test_module)
 
-      accept_alert do
-        click_link "Redo Module Setup"
-      end
+      click_link "Redo Module Setup"
 
       within '#best-match' do
         click_button 'Yes'

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Student, type: :model do
   describe 'validations' do
     it {should validate_presence_of :name}
     it {should validate_uniqueness_of(:slack_id).scoped_to(:turing_module_id)}
+    it {should validate_uniqueness_of(:populi_id)}
   end
   
   describe 'relationships' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,7 +73,7 @@ RSpec.configure do |config|
 
   WebMock.disable_net_connect!(allow_localhost: true)
 
-  Capybara.javascript_driver = :selenium_chrome
+  Capybara.javascript_driver = :selenium_chrome_headless
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [x ] Refactor

## Description of Change:

When redoing module setup, any students that were already in the module from the initial setup should be removed.

Refactors importing students to use upsert_all rather than making queries for each individual student.

Changes the capybara javascript driver to use the headless version of chrome so that the developer will not have random chrome windows popping up.

## Requested feedback:

n/a

## Check the correct boxes

- [x ] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

<img src="https://media1.giphy.com/media/wQCWMHY9EHLfq/giphy.gif"/>
