### PR TITLE
Zoom aliases display for all students regardless of status

### DIFF
--- a/app/views/shared/_zoom_attendance_table.html.erb
+++ b/app/views/shared/_zoom_attendance_table.html.erb
@@ -22,23 +22,16 @@
           <% end %>
           <td class='<%= student_attendance.status %>'><%= student_attendance.status %></td>
           <td class='duration'><%= student_attendance.duration %></td>
-
-          <% if student_attendance.absent? %>
-            <td class="alias-used">N/A</td>
-          <% else %>
-            <td class="alias-used"><%= student_attendance.student.zoom_alias_names.to_sentence %>
+          <td class="alias-used">
+            <%= student_attendance.student.zoom_alias_names.to_sentence %>
             <%= link_to "Edit", student_path(student_attendance.student), class: "s-button danger alias-correction" %>
-            </td>
-          <% end %>
-
-          <% unless student_attendance.present? %>
-            <td id='student-aliases-<%= student_attendance.student.id %>'>
-              <%= form_with model: [@attendance, student_attendance.student], class: "alias-correction" do |f| %>
-                <%= f.select :zoom_alias, facade.alias_options_for(student_attendance.student), {}, class: "alias-correction" %>
-                <%= f.submit "Save Zoom Alias", class: "s-button alias-correction" %>
-              <% end %>
-            </td>
-          <% end %>
+          </td>
+          <td id='student-aliases-<%= student_attendance.student.id %>'>
+            <%= form_with model: [@attendance, student_attendance.student], class: "alias-correction" do |f| %>
+              <%= f.select :zoom_alias, facade.alias_options_for(student_attendance.student), {}, class: "alias-correction" %>
+              <%= f.submit "Save Zoom Alias", class: "s-button alias-correction" %>
+            <% end %>
+          </td>
         </section>
       </tr>
     <% end %>

--- a/spec/features/attendances/zoom_aliases_correction_spec.rb
+++ b/spec/features/attendances/zoom_aliases_correction_spec.rb
@@ -111,11 +111,24 @@ RSpec.describe 'attendance show page' do
     end
   end
 
-  it 'shows the alias used for the student' do
+  it 'shows the aliases used for the student' do
     leo = @test_module.students.find_by(name: "Leo Banos Garcia")
+
+    within "#student-aliases-#{leo.id}" do
+      select("Sam Cox (He/Him) BE")
+      click_button "Save Zoom Alias"
+    end
+   
+    within "#student-aliases-#{leo.id}" do
+      select("Anhnhi T BE she/her/hers")
+      click_button "Save Zoom Alias"
+    end
+
     within "#student-#{leo.id}" do
       within '.alias-used' do
         expect(page).to have_content("Leo BG# BE")
+        expect(page).to have_content("Anhnhi T BE she/her/hers")
+        expect(page).to have_content("Sam Cox (He/Him) BE")
       end
     end
   end

--- a/spec/features/attendances/zoom_aliases_correction_spec.rb
+++ b/spec/features/attendances/zoom_aliases_correction_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe 'attendance show page' do
     end
 
     expect(current_path).to eq(attendance_path(Attendance.last))
-    expect(page).to_not have_css("#student-aliases-#{lacey.id}")
     
     within "#student-#{lacey.id}" do
       expect(page).to have_content("present")


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented ___x_ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Allows zoom aliases to display for all students regardless of attendance status. Previously, if a student was absent we wouldn't show any alias information. This was confusing because a student can still have zoom aliases even if they aren't present or tardy. Also, previously we were removing the zoom alias drop down if a student was present, however an instructor might still want to assign an alias to a student for future use even if it won't change their present status for the current attendance.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [ x] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

<img src="https://media0.giphy.com/media/ThrM4jEi2lBxd7X2yz/giphy.gif"/>
