### PR TITLE
Gracefully handles error when a zoom meeting has no participants

### DIFF
--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -22,6 +22,7 @@ class ZoomMeeting < Meeting
   end
 
   def take_participant_attendance
+    raise ZoomMeeting.participants_not_ready_error if participant_report.nil?
     create_zoom_aliases if zoom_aliases.empty? # If we are retaking attendance no need to recreate zoom aliases
     grouped_participants = participants.group_by(&:name)
     turing_module.students.each do |student|
@@ -83,6 +84,10 @@ private
     InvalidMeetingError.new("It looks like that Zoom link is for a Personal Meeting Room. You will need to use a unique meeting instead.")
   end
 
+  def self.participants_not_ready_error
+    InvalidMeetingError.new("That Zoom Meeting does not have any participants yet. This could be because the meeting is still in progress. Please try again later.")
+  end
+
   def participant_report
     @report ||= ZoomService.participant_report(self.meeting_id)[:participants]
   end
@@ -103,7 +108,6 @@ private
   end
 
   def calculate_duration(participant_records) 
-    
     ((participant_records.sum(&:duration).to_f) / 60 ).round
   end
 

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -128,4 +128,30 @@ RSpec.describe 'Creating a Zoom Attendance' do
       expect(page).to have_content("It appears you have entered an invalid Zoom Meeting ID. Please double check the Meeting ID and try again.")
     end
   end
+
+  context "before the participant report is complete" do
+    before(:each) do
+      @test_zoom_meeting_id = 95490216907
+      @test_module = create(:setup_module)
+
+      stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
+        .to_return(body: File.read('spec/fixtures/zoom/participant_report_not_ready.json'))
+
+      stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_zoom_meeting_id}") \
+        .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))
+
+      stub_request(:post, ENV['POPULI_API_URL']).
+        with(body: {"task"=>"getCourseInstanceMeetings", "instanceID"=>@test_module.populi_course_id}).
+        to_return(status: 200, body: File.read('spec/fixtures/populi/course_meetings.xml'))
+    end
+
+    it 'flashes a message letting the user know the report isnt ready yet' do
+      visit turing_module_path(@test_module)
+
+      fill_in :attendance_meeting_url, with: "https://turingschool.zoom.us/j/#{@test_zoom_meeting_id}"
+      click_button 'Take Attendance'
+
+      expect(page).to have_content("That Zoom Meeting does not have any participants yet. This could be because the meeting is still in progress. Please try again later.")
+    end
+  end
 end

--- a/spec/fixtures/zoom/participant_report_not_ready.json
+++ b/spec/fixtures/zoom/participant_report_not_ready.json
@@ -1,0 +1,4 @@
+{
+  "code": 3001,
+  "message": "Meeting does not exist: 93544999168."
+}


### PR DESCRIPTION
__x__ Wrote Tests _x___ Implemented __x__ Reviewed

## Necessary checkmarks:

- [ x] All Tests are Passing in all environments

- [ x] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

Displays a flash message letting the user know what happened when they try to take attendance for a zoom meeting that has no participants. This happens when the user tries to take attendance for an in progress meeting. Previously it was causing a server error.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [ x] My code has no unused/commented out code
- [ x] My code has no binding.pry's
- [ x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have fully tested my code

<img src="https://media1.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif"/>
