### PR TITLE
Aliases from other meetings

### DIFF
--- a/app/facades/attendance_show_facade.rb
+++ b/app/facades/attendance_show_facade.rb
@@ -6,8 +6,10 @@ class AttendanceShowFacade
   end
   
   def alias_options_for(student)
-    @attendance.meeting.unclaimed_aliases.sort_by do |name, id|
-      -1 * string_distance(student.name, name)
+    @attendance.turing_module.unclaimed_aliases.sort_by do |zoom_alias|
+      -1 * string_distance(student.name, zoom_alias.name)
+    end.map do |zoom_alias|
+      [zoom_alias.name, zoom_alias.id]
     end
   end
 

--- a/app/models/turing_module.rb
+++ b/app/models/turing_module.rb
@@ -14,6 +14,10 @@ class TuringModule < ApplicationRecord
   validates_presence_of :program
   enum program: [:FE, :BE, :Combined, :Launch]
 
+  def unclaimed_aliases
+    ZoomAlias.where(turing_module_id: self.id).where(student_id: nil)
+  end
+
   def name
     "#{self.program} Mod #{self.module_number}"
   end

--- a/app/models/zoom_meeting.rb
+++ b/app/models/zoom_meeting.rb
@@ -55,12 +55,6 @@ class ZoomMeeting < Meeting
     participants.uniq(&:name)
   end
 
-  def unclaimed_aliases
-    # We don't necessarily care which zoom alias is picked for each name, 
-    # so just get the one with the minimum id
-    self.zoom_aliases.where(student: nil).group(:name).minimum(:id)
-  end
-
   def find_student_from_participant(participant)
     zoom_alias = find_or_create_zoom_alias(participant.name)
     return zoom_alias.student if zoom_alias

--- a/spec/models/turing_module_spec.rb
+++ b/spec/models/turing_module_spec.rb
@@ -15,6 +15,32 @@ RSpec.describe TuringModule, type: :model do
 
 
   describe 'instance methods' do
+    describe "#unclaimed_aliases" do
+      before :each do
+        @attendance = create(:attendance)
+        @module = @attendance.turing_module
+        @other_attendance = create(:attendance, turing_module: @module)
+        
+        @unclaimed = create_list(:zoom_alias, 2, zoom_meeting: @attendance.meeting, turing_module: @module)
+        @other_unclaimed = create_list(:zoom_alias, 2, zoom_meeting: @other_attendance.meeting, turing_module: @module)
+        @claimed = create_list(:alias_for_student, 2, zoom_meeting: @attendance.meeting, turing_module: @module)
+        @other_claimed = create_list(:alias_for_student, 2, zoom_meeting: @other_attendance.meeting, turing_module: @module)
+      end
+
+      it 'returns all aliases from all zoom meetings that have no student assigned' do
+        expect(@module.unclaimed_aliases.sort).to eq(@unclaimed + @other_unclaimed)
+      end
+
+      it 'Does not include aliases from other modules' do
+        expect {
+          create(:zoom_alias) 
+        }.to_not change {
+          @module.unclaimed_aliases.length
+        }
+      end
+    end
+
+
     describe '#name' do
       it 'returns a combo of the module number and program' do
         test_module = create(:setup_module)

--- a/spec/models/zoom_meeting_spec.rb
+++ b/spec/models/zoom_meeting_spec.rb
@@ -6,28 +6,4 @@ RSpec.describe ZoomMeeting do
     it {should have_one :attendance}
     it {should have_one(:turing_module).through(:attendance)}
   end
-
-  describe "instance methods" do
-    describe "#unclaimed_aliases" do
-      before :each do
-        @zoom = create(:zoom_meeting)
-        @unclaimed = create_list(:zoom_alias, 2, zoom_meeting: @zoom)
-        @claimed = create_list(:alias_for_student, 2, zoom_meeting: @zoom)
-      end
-
-      it 'returns a hash of name/id of all aliases with no student' do
-        expected = {
-          @unclaimed.first.name => @unclaimed.first.id,
-          @unclaimed.second.name => @unclaimed.second.id
-        }
-        expect(@zoom.unclaimed_aliases).to eq(expected)
-      end
-
-      it 'is unique by name' do
-        name = @unclaimed.first.name
-        create(:zoom_alias, zoom_meeting: @zoom, name: name)
-        expect(@zoom.unclaimed_aliases.length).to eq(2)
-      end
-    end
-  end
 end


### PR DESCRIPTION
__x__ Wrote Tests _x___ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [ x] The code will run locally

## Type of change

- [ ] New feature
- [x ] Bug Fix
- [ ] Refactor

## Description of Change:

The zoom alias drop downs now show unclaimed aliases from all of a module's meetings. Previously, it was only showing for the meeting which attendance is being taken, which means that a user would have to go back to other attendances to find the first occurrence of an alias in order to assign it to a student.

## Requested feedback:

n/a

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [x ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [x ] My code has no binding.pry's
- [x ] I have reviewed my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have fully tested my code

<img src="https://media2.giphy.com/media/DrO4Bm325pjhc0BRM0/giphy.gif"/>
