### PR TITLE
Upgrade Zoom Authentication to Server to Server Oauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,6 @@ gem 'faraday'
 # Implements Google Oauth
 gem 'omniauth-google-oauth2'
 
-# Generate JWT Token for Zoom API
-gem 'jwt'
-
 gem 'populi_api', git: 'https://github.com/turingschool/populi_api.git', branch: 'main'
 
 # String Matching algorithm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,6 @@ DEPENDENCIES
   fuzzy-string-match
   honeybadger (~> 5.2)
   importmap-rails
-  jwt
   kaminari
   launchy
   omniauth-google-oauth2

--- a/app/services/zoom_service.rb
+++ b/app/services/zoom_service.rb
@@ -1,15 +1,26 @@
 class ZoomService
   def self.meeting_details(meeting_id)
-    response = conn.get "/v2/meetings/#{meeting_id}"
-    parse_response(response)
+    try_request do 
+      conn.get "/v2/meetings/#{meeting_id}"
+    end
   end
 
   def self.participant_report(meeting_id)
-    response = conn.get "/v2/report/meetings/#{meeting_id}/participants?page_size=300"
-    parse_response(response)
+    try_request do
+      conn.get "/v2/report/meetings/#{meeting_id}/participants?page_size=300"
+    end
   end
 
 private
+  def self.try_request(&request)
+    body = parse_response(request.call)
+    if body[:code].to_i == 124
+      Rails.cache.delete("zoom_oauth_token")
+      body = parse_response(request.call)
+    end
+    return body
+  end
+
   def self.conn
     Faraday.new(
       url: 'https://api.zoom.us',
@@ -20,20 +31,23 @@ private
     )
   end
 
-  def self.access_token
-    Rails.cache.fetch("zoom_oauth_token", expires_in: 55.minutes) do
-      response = auth_conn.post
-      JSON.parse(response.body)["access_token"]
-    end
-  end  
-
   def self.auth_conn
     Faraday.new(url: "https://zoom.us/oauth/token") do |conn|
       conn.request :basic_auth, ENV["ZOOM_CLIENT_ID"], ENV["ZOOM_CLIENT_SECRET"]
-      conn.params["grant_type"] = "account_credentials"
-      conn.params["account_id"] = ENV["ZOOM_ACCOUNT_ID"]
     end
   end
+
+  def self.access_token
+    Rails.cache.fetch("zoom_oauth_token", expires_in: 55.minutes) do
+      response = auth_conn.post do |req|
+        req.body = {
+          account_id: ENV["ZOOM_ACCOUNT_ID"],
+          grant_type: "account_credentials"
+        }.to_query
+      end
+      JSON.parse(response.body)["access_token"]
+    end
+  end  
 
   def self.parse_response(response)
     JSON.parse(response.body, symbolize_names: true)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/spec/features/attendances/create_zoom_attendance_spec.rb
+++ b/spec/features/attendances/create_zoom_attendance_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
       @test_zoom_meeting_id = 95490216907
       @test_module = create(:setup_module)
 
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
       stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
         .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
 
@@ -71,6 +73,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
     end
 
     it 'shows a message if an invalid meeting id is entered' do
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
       stub_request(:get, "https://api.zoom.us/v2/meetings/#{@invalid_zoom_id}") \
         .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
 
@@ -85,6 +89,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
     end
 
     it 'shows a message if no meeting id is entered' do
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
       stub_request(:get, "https://api.zoom.us/v2/meetings/") \
         .to_return(body: File.read('spec/fixtures/zoom/endpoint_not_recognized.json'))
 
@@ -98,6 +104,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
     end
 
     it 'shows a message if a personal meeting room is entered' do
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
       stub_request(:get, "https://api.zoom.us/v2/meetings/#{@invalid_zoom_id}") \
         .to_return(body: File.read('spec/fixtures/zoom/meeting_details_personal_room.json'))
 
@@ -113,6 +121,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
 
   context "With invalid Zoom URLs" do
     it "Shows an error message if the URL isn't continous, has spaces" do
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
       stub_request(:get, "https://api.zoom.us/v2/meetings/92831928801 928 319 288 01") \
       .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
 
@@ -126,6 +136,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
     end
 
     it "Shows an error message if the meeting ID in the URL is missing digits." do
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+      
       stub_request(:get, "https://api.zoom.us/v2/meetings/9634435576") \
       .to_return(body: File.read('spec/fixtures/zoom/meeting_details_invalid.json'))
 
@@ -143,6 +155,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
     before(:each) do
       @test_zoom_meeting_id = 95490216907
       @test_module = create(:setup_module)
+
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
 
       stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
         .to_return(body: File.read('spec/fixtures/zoom/participant_report_not_ready.json'))
@@ -170,6 +184,8 @@ RSpec.describe 'Creating a Zoom Attendance' do
       @test_zoom_meeting_id = 95490216907
       @test_module = create(:setup_module)
 
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+      
       stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
         .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
 

--- a/spec/features/attendances/duration_spec.rb
+++ b/spec/features/attendances/duration_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Duration" do
     @test_module = create(:setup_module_no_aliases)
     @test_zoom_meeting_id = 95490216907
 
+    allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+    
     stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
       .to_return(body: File.read('spec/fixtures/zoom/participant_report_for_duration.json'))
 

--- a/spec/features/attendances/populi_transfer_spec.rb
+++ b/spec/features/attendances/populi_transfer_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Populi Transfer' do
 
     @test_zoom_meeting_id = 96428502996
 
+    allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+    
     stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
       .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
 

--- a/spec/features/attendances/update_attendance_time_spec.rb
+++ b/spec/features/attendances/update_attendance_time_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Attendance Update' do
     @test_zoom_meeting_id = 95490216907
     @test_module = create(:setup_module)
 
+    allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+    
     stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
       .to_return(body: File.read('spec/fixtures/zoom/participant_report_for_attendance_update.json'))
 

--- a/spec/features/attendances/zoom_aliases_correction_spec.rb
+++ b/spec/features/attendances/zoom_aliases_correction_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'attendance show page' do
     @test_module = create(:setup_module)
     @test_zoom_meeting_id = 95490216907
 
+    allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
     stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_zoom_meeting_id}/participants?page_size=300") \
         .to_return(body: File.read('spec/fixtures/zoom/participant_report_for_name_matching.json'))
 

--- a/spec/fixtures/zoom/auth_token_expired.json
+++ b/spec/fixtures/zoom/auth_token_expired.json
@@ -1,0 +1,4 @@
+{
+  "code": 124,
+  "message": "Access token is expired."
+}

--- a/spec/services/zoom_service_spec.rb
+++ b/spec/services/zoom_service_spec.rb
@@ -1,32 +1,97 @@
 require 'rails_helper'
 
 RSpec.describe ZoomService do
-  before(:each) do
-    @test_meeting_id = '95490216907'
+  describe "Authorization", cache: true do
+    before :each do
+      @test_meeting_id = '95490216907'
+      @test_token = "test token"
+      @request_token_stub = stub_request(:post, "https://zoom.us/oauth/token") \
+                              .to_return(body: {access_token: @test_token}.to_json)
 
-    stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_meeting_id}") \
-      .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))
+      @meeting_details_stub = stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_meeting_id}") \
+                                  .with(headers: {Authorization: "Bearer #{@test_token}"}) \
+                                  .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))                         
+    end
 
-    stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_meeting_id}/participants?page_size=300") \
-      .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
+    context "token is not expired" do
+      it 'requests an oauth token when not stored in cache' do
+        expect(Rails.cache.fetch("zoom_oauth_token")).to be_nil
+        
+        ZoomService.meeting_details(@test_meeting_id)
+
+        expect(Rails.cache.fetch("zoom_oauth_token")).to eq(@test_token)
+        expect(@request_token_stub).to have_been_requested.times(1)
+        expect(@meeting_details_stub).to have_been_requested.times(1)
+      end
+
+      it 'uses the oauth token when stored in cache' do
+        Rails.cache.fetch("zoom_oauth_token") { @test_token } # write the oauth token to cache
+        ZoomService.meeting_details(@test_meeting_id)
+        expect(@request_token_stub).to_not have_been_requested
+        expect(@meeting_details_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "token is expired unexpectedly" do
+      before :each do
+        @expired_token = "expired token"
+        @expired_stub = stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_meeting_id}") \
+                          .with(headers: {Authorization: "Bearer #{@expired_token}"}) \
+                          .to_return(body: File.read('spec/fixtures/zoom/auth_token_expired.json'))                         
+
+        Rails.cache.fetch("zoom_oauth_token") { @expired_token } # Write the expired token to cache
+      end
+
+      it 'replaces the expired token with the new token in the cache' do
+        expect(Rails.cache.fetch("zoom_oauth_token")).to eq(@expired_token)        
+        ZoomService.meeting_details(@test_meeting_id)
+        expect(Rails.cache.fetch("zoom_oauth_token")).to eq(@test_token)        
+      end
+
+      it 'requests the new oauth token' do
+        ZoomService.meeting_details(@test_meeting_id)
+        expect(@request_token_stub).to have_been_requested.times(1)
+      end
+
+      it 'retries the request and sends back a valid response' do
+        response = ZoomService.meeting_details(@test_meeting_id)
+        expect(@expired_stub).to have_been_requested.times(1)
+        expect(@meeting_details_stub).to have_been_requested.times(1)
+        expect(response).to have_key(:start_time)
+      end
+    end
   end
 
-  it 'can get meeting details' do
-    response = ZoomService.meeting_details(@test_meeting_id)
-    expect(response).to be_a(Hash)
-    expect(response).to have_key(:start_time)
-    expect(response).to have_key(:id)
-    expect(response).to have_key(:topic)
-  end
+  describe 'api calls' do
+    before(:each) do
+      @test_meeting_id = '95490216907'
 
-  it 'can get past meeting participant report' do
-    response = ZoomService.participant_report(@test_meeting_id)
-    expect(response[:page_size]).to eq(300)
-    expect(response[:participants]).to be_an(Array)
-    expect(response[:participants].first).to be_a(Hash)
-    expect(response[:participants].first).to have_key(:user_id)
-    expect(response[:participants].first).to have_key(:name)
-    expect(response[:participants].first).to have_key(:user_email)
-    expect(response[:participants].first).to have_key(:join_time)
+      allow(ZoomService).to receive(:access_token) # Do nothing when fetching Zoom access token
+
+      stub_request(:get, "https://api.zoom.us/v2/meetings/#{@test_meeting_id}") \
+        .to_return(body: File.read('spec/fixtures/zoom/meeting_details.json'))
+
+      stub_request(:get, "https://api.zoom.us/v2/report/meetings/#{@test_meeting_id}/participants?page_size=300") \
+        .to_return(body: File.read('spec/fixtures/zoom/participant_report.json'))
+    end
+
+    it 'can get meeting details' do
+      response = ZoomService.meeting_details(@test_meeting_id)
+      expect(response).to be_a(Hash)
+      expect(response).to have_key(:start_time)
+      expect(response).to have_key(:id)
+      expect(response).to have_key(:topic)
+    end
+
+    it 'can get past meeting participant report' do
+      response = ZoomService.participant_report(@test_meeting_id)
+      expect(response[:page_size]).to eq(300)
+      expect(response[:participants]).to be_an(Array)
+      expect(response[:participants].first).to be_a(Hash)
+      expect(response[:participants].first).to have_key(:user_id)
+      expect(response[:participants].first).to have_key(:name)
+      expect(response[:participants].first).to have_key(:user_email)
+      expect(response[:participants].first).to have_key(:join_time)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,4 +95,13 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  config.before(:example, cache: true) do
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
+    Rails.cache.clear
+  end
+
+  config.after(:example, cache: true) do
+    allow(Rails).to receive(:cache).and_call_original
+  end
 end


### PR DESCRIPTION
____ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x ] All Tests are Passing in all environments

- [x ] The code will run locally

## Type of change

- [ ] New feature
- [ ] Bug Fix
- [x ] Refactor

## Description of Change:

Zoom is deprecating authentication to the Zoom API with JWT tokens. Now using server to server oauth instead. This requires us to send an additional request to obtain an access token. Tokens expire in 1 hour, so we are storing them in the low-level Rails cache and expiring them in 55 minutes. This PR also configures the production cache store as the memory store. Normally the memory store would not be a good production choice, but I'm going with it here since we're only storing this one token and we can always request a new token if we lose the cache somehow.

## Requested feedback:

Any thoughts on using the memory store in production? Any reasons this wouldn't be a good choice for this use case?

## Check the correct boxes

- [ x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x ] My code has no unused/commented out code
- [x ] My code has no binding.pry's
- [x ] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code

<img src="https://media0.giphy.com/media/3o6gDWzmAzrpi5DQU8/giphy.gif"/>
