### PR TITLE
Remove populi api gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ gem 'faraday'
 # Implements Google Oauth
 gem 'omniauth-google-oauth2'
 
-gem 'populi_api', git: 'https://github.com/turingschool/populi_api.git', branch: 'main'
-
 # String Matching algorithm
 gem 'fuzzy-string-match'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/turingschool/populi_api.git
-  revision: 5db05773e0bcff223602f3e1696c076d0f587a3e
-  branch: main
-  specs:
-    populi_api (0.8.0)
-      activesupport (>= 5.2, < 8.0)
-      faraday (>= 1.0, <= 2.0)
-      faraday_middleware (~> 1.0)
-      multi_xml (~> 0.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -141,8 +130,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     fugit (1.9.0)
@@ -384,7 +371,6 @@ DEPENDENCIES
   omniauth-google-oauth2
   orderly
   pg (~> 1.1)
-  populi_api!
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)

--- a/app/services/populi_service.rb
+++ b/app/services/populi_service.rb
@@ -5,10 +5,6 @@ class PopuliService
 
   def initialize
     check_env_vars
-    PopuliAPI.connect(
-        url: ENV["POPULI_API_URL"],  
-        access_key: ENV["POPULI_API_ACCESS_KEY"]
-    )
   end
 
   def get_person(id)
@@ -53,19 +49,19 @@ class PopuliService
 
 private
   def check_env_vars
-    if ENV["POPULI_API_URL"] == FAKE_POPULI_URL || ENV["POPULI_API2_URL"] == FAKE_POPULI_URL
+    if ENV["POPULI_API_URL"] == FAKE_POPULI_URL
       Rails.logger.warn("WARNING: POPULI_API_URL environment variable is not set. Using a fake url. This may cause issues with features that utilize the Populi API")
     end
-    if ENV["POPULI_API_ACCESS_KEY"] == FAKE_POPULI_ACCESS_KEY || ENV["POPULI_API2_ACCESS_KEY"] == FAKE_POPULI_ACCESS_KEY
+    if ENV["POPULI_API_ACCESS_KEY"] == FAKE_POPULI_ACCESS_KEY
       Rails.logger.warn("WARNING: POPULI_API_ACCESS_KEY environment variable is not set. Using a fake access key. This may cause issues with features that utilize the Populi API")
     end
   end
 
   def conn
     Faraday.new(
-      url: ENV["POPULI_API2_URL"],
+      url: ENV["POPULI_API_URL"],
       headers: {
-        'Authorization' => "Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}"
+        'Authorization' => "Bearer #{ENV["POPULI_API_ACCESS_KEY"]}"
       }
     )
   end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -3,5 +3,3 @@ FAKE_POPULI_ACCESS_KEY = "abc123"
 # set the populi url/key to a fake credentials if not set in the environment
 ENV["POPULI_API_URL"] ||= FAKE_POPULI_URL 
 ENV["POPULI_API_ACCESS_KEY"] ||= FAKE_POPULI_ACCESS_KEY
-ENV["POPULI_API2_URL"] ||= FAKE_POPULI_URL
-ENV["POPULI_API2_ACCESS_KEY"] ||= FAKE_POPULI_ACCESS_KEY

--- a/spec/features/attendances/populi_transfer_spec.rb
+++ b/spec/features/attendances/populi_transfer_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Populi Transfer' do
       with(
         body: {course_meeting_id: course_meeting_id_1, status: status_absent},
         headers: {
-      'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+      'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
         }).
       to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_not_found.json'))
       

--- a/spec/fixtures/populi/test_data/stub_requests.rb
+++ b/spec/fixtures/populi/test_data/stub_requests.rb
@@ -11,49 +11,49 @@ def stub_persons
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_1}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_1.json'))
   
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_2}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_2.json'))
   
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_3}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_3.json'))
   
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_4}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_4.json'))
 
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_5}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_5.json'))
 
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_6}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_6.json'))
 
   stub_request(:get, "https://turing-validation.populi.co/api2/people/#{personId_7}").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_person/get_person_7.json'))
 end
@@ -67,28 +67,28 @@ def stub_get_enrollments
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_1}/students").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_enrollments/get_enrollments.json'))
 
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_2}/students").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_enrollments/get_enrollments.json'))
   
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_3}/students").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_enrollments/get_enrollments.json'))
   
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_4}/students").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_enrollments/get_enrollments.json'))
 end
@@ -97,7 +97,7 @@ def stub_academic_terms
   stub_request(:get, "https://turing-validation.populi.co/api2/academicterms").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_terms/get_academic_terms.json'))
 end
@@ -106,7 +106,7 @@ def stub_current_academic_term
   stub_request(:get, "https://turing-validation.populi.co/api2/academicterms/current").
     with(
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_current_academic_term/current_academic_term.json')) 
 end
@@ -119,7 +119,7 @@ def stub_course_offerings_by_term
     with(
       body: {"{\"academic_term_id\":\"295946\"}"=>nil},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_courseofferings_by_term/get_courseofferings_by_term_1.json'))
 
@@ -127,7 +127,7 @@ def stub_course_offerings_by_term
     with(
       body: {"academic_term_id":295946}.to_json,
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_courseofferings_by_term/get_courseofferings_by_term_1.json'))
   
@@ -135,7 +135,7 @@ def stub_course_offerings_by_term
     with(
       body: {"{\"academic_term_id\":\"295898\"}"=>nil},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_courseofferings_by_term/get_courseofferings_by_term_2.json'))
 
@@ -143,7 +143,7 @@ def stub_course_offerings_by_term
     with(
       body: {"academic_term_id":295898}.to_json,
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_courseofferings_by_term/get_courseofferings_by_term_2.json'))
 end
@@ -169,7 +169,7 @@ def stub_successful_update_student_attendance
   with(
     body: {course_meeting_id: course_meeting_id, status: status_present},
     headers: {
-  'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+  'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
     }).
   to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_1.json'))
 
@@ -177,7 +177,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_1.json'))
   
@@ -185,7 +185,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_2.json'))
   
@@ -193,7 +193,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_3.json'))
   
@@ -201,7 +201,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_4.json'))
   
@@ -209,7 +209,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_5.json'))
   
@@ -217,7 +217,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_6.json'))
 
@@ -225,7 +225,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_1.json'))
   
@@ -233,7 +233,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_2.json'))
   
@@ -241,7 +241,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_3.json'))
   
@@ -249,7 +249,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_4.json'))
   
@@ -257,7 +257,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_5.json'))
   
@@ -265,7 +265,7 @@ def stub_successful_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_6.json'))
 end
@@ -297,7 +297,7 @@ def stub_failed_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_course_meeting_does_not_exist.json'))
 
@@ -305,7 +305,7 @@ def stub_failed_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_2, status: status},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_course_offering_not_found.json'))
 
@@ -313,7 +313,7 @@ def stub_failed_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_3, status: status},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_enrollment_does_not_exist.json'))
 
@@ -321,7 +321,7 @@ def stub_failed_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_4, status: status},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_finalized_enrollment_error.json'))
 end
@@ -343,7 +343,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_1.json'))
   
@@ -351,7 +351,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_present},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_2.json'))
   
@@ -359,7 +359,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_3.json'))
   
@@ -367,7 +367,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_absent},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/error/update_student_attendance_no_course_meeting.json'))
   
@@ -375,7 +375,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_5.json'))
   
@@ -383,7 +383,7 @@ def stub_single_failure_update_student_attendance
     with(
       body: {course_meeting_id: course_meeting_id_1, status: status_tardy},
       headers: {
-    'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+    'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
       }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/update_student_attendance/success/update_student_attendance_success_6.json'))
 end
@@ -394,7 +394,7 @@ def stub_course_meetings
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_id}/coursemeetings").
   with(
     headers: {
-  'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+  'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
     }).
   to_return(status: 200, body: File.read('spec/fixtures/populi/get_course_meetings/get_course_meetings.json'))
 end
@@ -405,7 +405,7 @@ def stub_course_meetings_for_duration
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_id}/coursemeetings").
   with(
     headers: {
-  'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+  'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
     }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_course_meetings/get_course_meetings_for_duration.json'))
 end
@@ -416,7 +416,7 @@ def stub_course_meetings_for_half_hours
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings/#{course_offering_id}/coursemeetings").
   with(
     headers: {
-  'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+  'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
     }).
     to_return(status: 200, body: File.read('spec/fixtures/populi/get_course_meetings/get_course_meetings_for_half_hours.json'))
 end
@@ -425,7 +425,7 @@ def stub_course_meetings_nil
   stub_request(:get, "https://turing-validation.populi.co/api2/courseofferings//coursemeetings").
   with(
     headers: {
-  'Authorization'=>"Bearer #{ENV["POPULI_API2_ACCESS_KEY"]}",
+  'Authorization'=>"Bearer #{ENV["POPULI_API_ACCESS_KEY"]}",
     }).
   to_return(status: 200, body: File.read('spec/fixtures/populi/get_course_meetings/get_course_meetings.json'))
 end


### PR DESCRIPTION
____ Wrote Tests __X__ Implemented __X__ Reviewed

## Necessary checkmarks:

- [X] All Tests are Passing in all environments

- [X] The code will run locally

## Type of change

- [ ] New feature
- [ ] Bug Fix
- [X] Refactor

## Description of Change:

    description: Removed all instances of the populi_api gem bc of depreciated api.  Updated env variables to only using the new populi api access keys 

- update: Remove populi_api gem
- fix: Replace populi_api2 env variable names with populi_api
- fix: Update check_env and removed connection to legacy populi_api gem


## Requested feedback:

    

## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link:
https://media.giphy.com/media/L2lmbNXoRBB2WiJqEB/giphy.gif?cid=790b7611tgayeig9b792ns6s5oql61s3iapndmda9gf8jkck&ep=v1_gifs_search&rid=giphy.gif&ct=g