### PR TITLE
Option to remove zoom alias from instructor

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -52,6 +52,12 @@
   }
 }
 
+.instructor-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .pagination span {
   border: 1px solid #DDD;
   border-radius: 5px;

--- a/app/controllers/user/attendances_controller.rb
+++ b/app/controllers/user/attendances_controller.rb
@@ -34,9 +34,14 @@ class User::AttendancesController < User::BaseController
   end
 
   def update_zoom_alias_as_an_instructor
-    instructor = Student.find_or_create_by(name: "Instructor", turing_module_id: params[:turing_module_id])
-    zoom_alias = ZoomAlias.find_by(name: "#{params[:attendance][:zoom_alias]}")
-    zoom_alias.update(student: instructor)
+    if params[:commit] == "Remove"
+      zoom_alias = ZoomAlias.find(params[:zoom_alias])
+      zoom_alias.update(student: nil)
+    else 
+      instructor = Student.find_or_create_by(name: "Instructor", turing_module_id: params[:turing_module_id])
+      zoom_alias = ZoomAlias.find_by(name: "#{params[:attendance][:zoom_alias]}")
+      zoom_alias.update(student: instructor)
+    end
     @attendance.rerecord
     redirect_to attendance_path(@attendance)
   end

--- a/app/facades/attendance_show_facade.rb
+++ b/app/facades/attendance_show_facade.rb
@@ -26,7 +26,8 @@ class AttendanceShowFacade
 
   def instructor_zoom_aliases
     turing_module_id = @attendance.turing_module.id
-    if instructor = Student.instructors(turing_module_id).first
+    instructor = Student.instructors(turing_module_id).first
+    if instructor && instructor.zoom_aliases.any?
       return instructor.zoom_aliases
     else
       return false

--- a/app/views/shared/_instructor_zoom_aliases.html.erb
+++ b/app/views/shared/_instructor_zoom_aliases.html.erb
@@ -1,11 +1,22 @@
 <div class="list_of_instructors">
   <% if facade.instructor_zoom_aliases %>
     <h3>Instructors Present In Meeting:</h3>
-    <% facade.instructor_zoom_aliases.each do |zoom_alias| %>
-    <ul>
-      <li><%= zoom_alias.name %></li>
-    </ul>
-    <% end %>
+    <div class="instructor-form">
+      <% facade.instructor_zoom_aliases.each do |zoom_alias| %>
+        <div class="zoom-alias-<%= zoom_alias.id %>">
+          <div class="zoom-name">
+            <%= zoom_alias.name %>
+          </div>
+          <div class="instructor_zoom_alias_removal_form">
+            <%= form_with model: [@attendance], url: attendance_instructor_path(@attendance), class: "alias-correction" do |f| %>
+              <%= hidden_field_tag :turing_module_id, "#{facade.turing_module_id}" %>
+              <%= hidden_field_tag :zoom_alias, "#{zoom_alias.id}" %>
+              <%= f.submit "Remove", class: "s-button update-btn" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
   <% else %>
     <p>No zoom aliases have been assigned as instructors yet.</p>
   <% end %>

--- a/spec/features/attendances/zoom_aliases_correction_spec.rb
+++ b/spec/features/attendances/zoom_aliases_correction_spec.rb
@@ -174,4 +174,33 @@ RSpec.describe 'attendance show page' do
 
     expect { click_button 'Take Attendance' }.to_not change { ZoomAlias.count }
   end
+
+  it 'allows user to remove zoom alias of instructors' do
+    student_id = create(:student, turing_module: @test_module, name: "Instructor").id
+    create_list(:student_attendance_present, 1, attendance: @attendance, student_id: student_id)
+    instructor_alias = create_list(:zoom_alias, 2, turing_module: @attendance.turing_module, zoom_meeting_id: @attendance.meeting_id, student_id: student_id) # Instructor_aliases
+    
+    visit attendance_path(@attendance)
+
+    within ".zoom-alias-#{instructor_alias.first.id}" do
+      expect(page).to have_content(instructor_alias.first.name)
+      expect(page).to have_button("Remove")
+      click_button("Remove")
+    end
+  
+    within ".zoom-alias-#{instructor_alias.second.id}" do
+      expect(page).to have_content(instructor_alias.second.name)
+      expect(page).to have_button("Remove")
+      click_button("Remove")
+    end
+
+    expect(current_path).to eq(attendance_path(@attendance))
+
+    within ".list_of_instructors" do
+      expect(page).to_not have_content(instructor_alias.first.name)
+      expect(page).to_not have_content(instructor_alias.second.name)
+    end
+    
+    expect(page).to have_content("No zoom aliases have been assigned as instructors yet.")
+  end
 end


### PR DESCRIPTION
_X_ Wrote Tests _X_ Implemented _X_ Reviewed

## Necessary checkmarks:

- [X] All Tests are Passing in all environments

- [X] The code will run locally

## Type of change

- [X] New feature
- [ ] Bug Fix
- [ ] Refactor

## Description of Change:

    description: Add remove button for Instructor zoom aliases

## Requested feedback:

    I'd like feedback on...

## Check the correct boxes

- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [X] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [X] My code has no unused/commented out code
- [X] My code has no binding.pry's
- [X] I have reviewed my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link:

<div class="tenor-gif-embed" data-postid="11600152" data-share-method="host" data-aspect-ratio="1.78571" data-width="100%"><a href="https://tenor.com/view/cat-remove-work-eyeglass-cute-gif-11600152">Cat Remove GIF</a>from <a href="https://tenor.com/search/cat-gifs">Cat GIFs</a></div> <script type="text/javascript" async src="https://tenor.com/embed.js"></script>
