### PR TITLE
feat: Add delete all zoomalises to inning rollerover job

### DIFF
--- a/app/sidekiq/inning_rollover_job.rb
+++ b/app/sidekiq/inning_rollover_job.rb
@@ -2,6 +2,7 @@ class InningRolloverJob
   include Sidekiq::Job
 
   def perform(inning_id)
+    ZoomAlias.all.destroy_all
     inning = Inning.find(inning_id)
     inning.make_current_inning
     inning.create_turing_modules

--- a/spec/sidekiq/jobs/inning_rollover_spec.rb
+++ b/spec/sidekiq/jobs/inning_rollover_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe InningRolloverJob, type: :job do
       expect(@inning2.turing_modules.where(module_number: 6).count).to eq(1)
     end
 
+    it 'removes all zoom_aliases from prior modules' do
+      InningRolloverJob.perform_async(@inning2.id)
+
+      expect(ZoomAlias.count).to eq(0)
+    end
+
     it 'resets the modules for all users' do
       @inning1.create_turing_modules
       user1 = create(:user, turing_module: @inning1.turing_modules.first)
@@ -54,7 +60,7 @@ RSpec.describe InningRolloverJob, type: :job do
       expect(user3.turing_module_id).to_not eq(nil)
 
       InningRolloverJob.perform_async(@inning2.id)
-      
+
       expect(user1.reload.turing_module_id).to eq(nil)
       expect(user2.reload.turing_module_id).to eq(nil)
       expect(user3.reload.turing_module_id).to eq(nil)

--- a/spec/sidekiq/jobs/inning_rollover_spec.rb
+++ b/spec/sidekiq/jobs/inning_rollover_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe InningRolloverJob, type: :job do
     it 'creates turing modules for the new inning' do
       expect(@inning2.turing_modules.count).to eq(0)
       InningRolloverJob.perform_async(@inning2.id)
-      
+
       expect(@inning2.turing_modules.count).to eq(13)
 
       expect(@inning2.turing_modules.where(program: 'FE').count).to eq(3)
@@ -44,6 +44,12 @@ RSpec.describe InningRolloverJob, type: :job do
     end
 
     it 'removes all zoom_aliases from prior modules' do
+      @inning1.create_turing_modules
+      turing_mod1 = @inning1.turing_modules.first
+      create_list(:zoom_alias, 7, turing_module: turing_mod1)
+
+      expect(ZoomAlias.count).to eq(7)
+
       InningRolloverJob.perform_async(@inning2.id)
 
       expect(ZoomAlias.count).to eq(0)


### PR DESCRIPTION
__x__ Wrote Tests __x__ Implemented __x__ Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [ ] New feature
- [x] Bug Fix
- [ ] Refactor

## Description of Change:

    description: updated inning roller over job to destroy all ZoomAliases. 
        - needed to do this bc prior student and zoom_aliases relationships prevented the current inning from bringing in unassigned zoom_aliases 

## Requested feedback:

    I put in a very small test but would like feedback if it's actually testing anything 
## Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

## Testing Changes

- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no binding.pry's
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch

Link: https://media.giphy.com/media/GBg58w14FovtuzHykg/giphy.gif?cid=790b7611wkxo50qinlbupc3o7m6yfzk0b5ckog8jrg6ay06q&ep=v1_gifs_search&rid=giphy.gif&ct=g
